### PR TITLE
[FEAT] 곡 검색하기 구현, 보관함-좋아요 뮤멘트 추가사항  #14  #15

### DIFF
--- a/src/controllers/MusicController.ts
+++ b/src/controllers/MusicController.ts
@@ -71,7 +71,25 @@ const getMumentList = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ * @ROUTE GET /search?keyword=
+ * @DESC 곡 검색창에서 검색한 음악 리스트 가져오기
+ */
+const getMusicListBySearch = async (req: Request, res: Response) => {
+    const { keyword } = req.query;
+
+    try {
+        const data = await MusicService.getMusicListBySearch(keyword as string);
+
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.SEARCH_MUSIC_LIST_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 export default {
     getMusicAndMyMument,
     getMumentList,
+    getMusicListBySearch,
 };

--- a/src/interfaces/like/LikeInfo.ts
+++ b/src/interfaces/like/LikeInfo.ts
@@ -21,6 +21,7 @@ export interface LikeMumentInfo {
 }
 
 export interface LikeMumentUserInfo {
+    _id: mongoose.Types.ObjectId;
     name: string;
     image: string;
 }

--- a/src/interfaces/music/MusicResponseDto.ts
+++ b/src/interfaces/music/MusicResponseDto.ts
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+export interface MusicResponseDto {
+    _id: mongoose.Types.ObjectId;
+    name: string;
+    artist: string;
+    image: string;
+}

--- a/src/models/Like.ts
+++ b/src/models/Like.ts
@@ -17,6 +17,9 @@ const LikeSchema = new mongoose.Schema({
                 ref: 'Mument',
             },
             user: {
+                _id: {
+                    type: mongoose.Types.ObjectId,
+                },
                 name: {
                     type: String,
                     required: true,
@@ -27,6 +30,9 @@ const LikeSchema = new mongoose.Schema({
                 },
             },
             music: {
+                _id: {
+                    type: mongoose.Types.ObjectId,
+                },
                 name: {
                     type: String,
                     required: true,

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -18,6 +18,7 @@ const message = {
     // music
     FIND_MUSIC_MYMUMENT_SUCCESS: '곡 상세, 나의 뮤멘트 조회 성공',
     READ_MUSIC_MUMENTLIST_SUCCESS: '뮤멘트 리스트 조회 성공',
+    SEARCH_MUSIC_LIST_SUCCESS: '곡 검색하기 성공',
 };
 
 export default message;

--- a/src/routes/MusicRouter.ts
+++ b/src/routes/MusicRouter.ts
@@ -15,4 +15,6 @@ router.get('/:musicId/:userId/order', [
     query('default').isString().isIn(['Y', 'N']),
 ], MusicController.getMumentList);
 
+router.get('/search', MusicController.getMusicListBySearch);
+
 export default router;

--- a/src/services/MusicService.ts
+++ b/src/services/MusicService.ts
@@ -3,6 +3,7 @@ import { MumentInfo } from '../interfaces/mument/MumentInfo';
 import { MusicMumentListResponseDto } from '../interfaces/music/MusicMumentListResponseDto';
 
 import { MusicMyMumentResponseDto } from '../interfaces/music/MusicMyMumentResponseDto';
+import { MusicResponseDto } from '../interfaces/music/MusicResponseDto';
 import Like from '../models/Like';
 import Mument from '../models/Mument';
 import Music from '../models/Music';
@@ -130,7 +131,30 @@ const getMumentList = async(musicId: string, userId: string, isLikeOrder: boolea
     }
 };
 
+const getMusicListBySearch = async (keyword: string): Promise<MusicResponseDto[]> => {
+    const regex = (pattern: string) => new RegExp(`.*${pattern}.*`);
+
+    try {
+        const musicRegex = regex(keyword);
+
+        const musicList = await Music.find({
+            $or: [
+                {
+                    name: { $regex: musicRegex },
+                },
+                {
+                    artist: { $regex: musicRegex },
+                },
+            ],
+        });
+        return musicList;
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
 export default {
     getMusicAndMyMument,
     getMumentList,
+    getMusicListBySearch,
 };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -50,9 +50,9 @@ const getMyMumentList = async (userId: string): Promise<UserMumentListResponseDt
                     },
                     music: {
                         _id: !music ? null : music._id,
-                        name: !music ? '존재하지 않는 음악' : music.name,
-                        artist: !music ? '존재하지 않는 음악' : music.artist,
-                        image: !music ? '존재하지 않는 음악' : music.image,
+                        name: !music ? 'nonexistence' : music.name,
+                        artist: !music ? 'onexistence' : music.artist,
+                        image: !music ? 'nonexistence' : music.image,
                     },
                     isFirst: mument.isFirst,
                     impressionTag: mument.impressionTag,
@@ -96,10 +96,9 @@ const getLikeMumentList = async (userId: string): Promise<UserMumentListResponse
             return +new Date(a.createdAt) - +new Date(b.createdAt);
         });
 
-        console.log(myMumentList.mument);
-
         const data = await Promise.all(
             myMumentList.mument.map((mument: any) => {
+
                 const result: MumentResponseDto = {
                     _id: mument._id,
                     user: {
@@ -108,6 +107,7 @@ const getLikeMumentList = async (userId: string): Promise<UserMumentListResponse
                         name: mument.user.name,
                     },
                     music: {
+                        _id: mument.music._id,
                         name: mument.music.name,
                         artist: mument.music.artist,
                         image: mument.music.image,
@@ -117,7 +117,7 @@ const getLikeMumentList = async (userId: string): Promise<UserMumentListResponse
                     feelingTag: mument.feelingTag,
                     content: mument.content,
                     isPrivate: mument.isPrivate,
-                    likeCount: mument.likeCount,
+                    likeCount: 0, //쓰이지 않음
                     isLiked: true,
                     createdAt: dayjs(mument.createdAt).format('D MMM, YYYY'),
                     year: Number(dayjs(mument.createdAt).format('YYYY')),

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -5,7 +5,7 @@ import Music from '../models/Music';
 import dayjs from 'dayjs';
 import Like from '../models/Like';
 import { MumentResponseDto } from '../interfaces/mument/MumentResponseDto';
-import { LikeMumentInfo } from '../interfaces/like/LikeInfo';
+import { LikeInfo } from '../interfaces/like/LikeInfo';
 
 const getMyMumentList = async (userId: string): Promise<UserMumentListResponseDto | null> => {
     try {
@@ -81,7 +81,7 @@ const getMyMumentList = async (userId: string): Promise<UserMumentListResponseDt
 
 const getLikeMumentList = async (userId: string): Promise<UserMumentListResponseDto | null> => {
     try {
-        const myMumentList = await Like.findOne({
+        const myMumentList: LikeInfo | null = await Like.findOne({
             'user._id': userId,
         });
 
@@ -91,6 +91,12 @@ const getLikeMumentList = async (userId: string): Promise<UserMumentListResponse
                 muments: [],
             };
         }
+
+        myMumentList.mument.sort((a, b) => {
+            return +new Date(a.createdAt) - +new Date(b.createdAt);
+        });
+
+        console.log(myMumentList.mument);
 
         const data = await Promise.all(
             myMumentList.mument.map((mument: any) => {


### PR DESCRIPTION
## **💿 DESCRIPTION**
1. 곡 검색하기 : 곡 검색창에 입력한 keyword가 곡 제목/아티스트 명에 포함된 음악들의 리스트 가져오기 #15

2. 보관함-좋아요 뮤멘트 #14 : 
- 좋아요한 user와 music의 _id 필드 추가
- 유저의 Like 다큐먼트 내부의 mument 리스트 최신순 정렬

## **🎙 RELATED ISSUE**
#14 #15

## **💃 REVIEW POINT**
- regex를 이용한 검색 쿼리 작성했어요!
- Like 다큐먼트의 mument 필드에 대해 리스트 최신순 정렬했어요!