### PR TITLE
[FEAT] 히스토리 조회 구현

### DIFF
--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -85,7 +85,7 @@ const getMumentHistory = async (req: Request, res: Response) => {
             res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
         }
 
-        res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_MUMENT_HISTORY_SUCCESS));
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_MUMENT_HISTORY_SUCCESS, data));
     } catch (error) {
         console.log(error);
         res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));

--- a/src/interfaces/mument/MumentHistoryResponseDto.ts
+++ b/src/interfaces/mument/MumentHistoryResponseDto.ts
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+import { MumentCardViewInterface } from './MumentCardViewInterface';
+
+export interface MumentHistoryResponseDto {
+    music: {
+        _id: mongoose.Schema.Types.ObjectId;
+        name: string;
+        artist: string;
+        image?: string;
+    };
+    mumentHistory?: MumentCardViewInterface[];
+}

--- a/src/interfaces/mument/MumentInfo.ts
+++ b/src/interfaces/mument/MumentInfo.ts
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 
 export interface MumentInfo {
+    _id: mongoose.Types.ObjectId;
     music: {
         _id: mongoose.Types.ObjectId;
     };
@@ -16,7 +17,7 @@ export interface MumentInfo {
     isPrivate: boolean;
     likeCount: number;
     isDeleted: boolean;
-    createdAt?: Date;
+    createdAt: Date;
 }
 
 export interface UserMumentInfo {

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -14,6 +14,7 @@ const message = {
     CREATE_MUMENT_SUCCESS: '뮤멘트 기록하기 성공',
     READ_MUMENT_SUCEESS: '뮤멘트 상세보기 성공',
     NOT_YOUR_MUMENT: '비밀글 입니다',
+    READ_MUMENT_HISTORY_SUCCESS: '뮤멘트 히스토리 조회 성공',
 
     // music
     FIND_MUSIC_MYMUMENT_SUCCESS: '곡 상세, 나의 뮤멘트 조회 성공',

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -9,7 +9,7 @@ router.post('/:userId/:musicId', MumentController.createMument);
 router.get('/:mumentId/:userId', MumentController.getMument);
 
 // 히스토리 조회
-router.get(':userId/:musicId/history', [
+router.get('/:userId/:musicId/history', [
     param('musicId').isString().isLength({ min: 24, max: 24 }),
     param('userId').isString().isLength({ min: 24, max: 24 }),
     query('default').isString().isIn(['Y', 'N']),

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -178,7 +178,7 @@ const getMumentHistory = async (userId: string, musicId: string, isLatestOrder:b
         };
 
         // 최종 리턴될 data
-        let mumentHistory: MumentCardViewInterface[];
+        const mumentHistory: MumentCardViewInterface[] = [];
         originalMumentList.reduce((ac, cur, index) => {
             mumentHistory[index] = {
                 ...cur.toObject(),
@@ -192,9 +192,6 @@ const getMumentHistory = async (userId: string, musicId: string, isLatestOrder:b
             music,
             mumentHistory,
         };
-        
-        // 지우기
-        console.log(data);
 
         return data;
 


### PR DESCRIPTION
## **💿 DESCRIPTION**
- 쿼리 값에 따라서 최신순/오래된순으로 조회 
- 곡 조회 결과가 없을 때 404에러 리턴
- 뮤멘트 히스토리가 없을 경우 mumentHistory 빈 배열 리턴
- 뮤멘트가 있을 경우, 날짜 형식 수정 및 isLiked 조회 후 myMument에 추가해서 리턴

## **🎙 RELATED ISSUE**
#13 

## **💃 REVIEW POINT**
