### PR TITLE
[FEAT] 처음/다시 태그 판단, 충돌 해결 후 머지

### DIFF
--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -51,7 +51,29 @@ const getMument = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ *  @ROUTE GET /mument/:userId/:musicId/is-first
+ *  @DESC 특정 음악에 대해 뮤멘트 기록하기 전 처음/다시 태그 판단
+ */
+const getIsFirst = async (req: Request, res: Response) => {
+    const { userId, musicId } = req.params;
+
+    try {
+        const data = await MumentService.getIsFirst(userId, musicId);
+
+        // 존재하지않는 musicId를 보낼 경우
+        if (!data) res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_ID));
+
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_ISFIRST_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 export default {
     createMument,
     getMument,
+    getIsFirst,
 };

--- a/src/interfaces/mument/IsFirstResponseDto.ts
+++ b/src/interfaces/mument/IsFirstResponseDto.ts
@@ -1,0 +1,3 @@
+export interface IsFirstResponseDto {
+    isFirst: boolean;
+}

--- a/src/interfaces/mument/MumentCreateDto.ts
+++ b/src/interfaces/mument/MumentCreateDto.ts
@@ -1,5 +1,3 @@
-import mongoose from 'mongoose';
-
 export interface MumentCreateDto {
     isFirst: boolean;
     impressionTag: number[];

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -14,6 +14,7 @@ const message = {
     CREATE_MUMENT_SUCCESS: '뮤멘트 기록하기 성공',
     READ_MUMENT_SUCEESS: '뮤멘트 상세보기 성공',
     NOT_YOUR_MUMENT: '비밀글 입니다',
+    READ_ISFIRST_SUCCESS: '뮤멘트 처음/다시 조회 성공',
 
     // music
     FIND_MUSIC_MYMUMENT_SUCCESS: '곡 상세, 나의 뮤멘트 조회 성공',

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -8,11 +8,13 @@ const router: Router = Router();
 router.post('/:userId/:musicId', MumentController.createMument);
 router.get('/:mumentId/:userId', MumentController.getMument);
 
-// 히스토리 조회
-router.get(':userId/:musicId/history', [
-    param('musicId').isString().isLength({ min: 24, max: 24 }),
-    param('userId').isString().isLength({ min: 24, max: 24 }),
-    query('default').isString().isIn(['Y', 'N']),
-], MumentController.getMumentHistory);
+// // 히스토리 조회
+// router.get(':userId/:musicId/history', [
+//     param('musicId').isString().isLength({ min: 24, max: 24 }),
+//     param('userId').isString().isLength({ min: 24, max: 24 }),
+//     query('default').isString().isIn(['Y', 'N']),
+// ], MumentController.getMumentHistory);
+
+router.get('/:userId/:musicId/is-first', MumentController.getIsFirst);
 
 export default router;

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -6,6 +6,7 @@ import Music from '../models/Music';
 import User from '../models/User';
 import Like from '../models/Like';
 import dayjs from 'dayjs';
+import { IsFirstResponseDto } from '../interfaces/mument/IsFirstResponseDto';
 
 const createMument = async (userId: string, musicId: string, mumentCreateDto: MumentCreateDto): Promise<PostBaseResponseDto | null> => {
     try {
@@ -110,7 +111,42 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
     }
 };
 
+const getIsFirst = async (userId: string, musicId: string): Promise<IsFirstResponseDto | null> => {
+    try {
+        const music = await Music.findById(musicId);
+        if (!music) return null;
+
+        const userMument = await Mument.findOne({
+            $and: [
+                {
+                    'user._id': { $eq: userId },
+                },
+                {
+                    'music._id': { $eq: musicId },
+                },
+                {
+                    isDeleted: { $eq: false },
+                },
+            ],
+        });
+
+        if (!userMument) {
+            return {
+                isFirst: true,
+            };
+        } else {
+            return {
+                isFirst: false,
+            };
+        }
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
+
 export default {
     createMument,
     getMument,
+    getIsFirst,
 };


### PR DESCRIPTION
## **💿 DESCRIPTION**
현재 사용자가 이 음악에 대한 뮤멘트를 처음 작성하는지 다시 작성하는지 조회합니다.
- 처음/다시 태그 판단
- git pull 후 충돌 해결, 머지

## **🎙 RELATED ISSUE**
#19

## **💃 REVIEW POINT**
- 삭제되지 않은 유저의 뮤멘트 기록을 findOne한 후, 존재하면 false를/존재하지 않으면 true를 보냅니다.
- 존재하지않는 음악에 대해 요청 시 404 처리했습니다.