### PR TITLE
[FEAT] 좋아요 기능 구현

### DIFF
--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import statusCode from '../modules/statusCode';
 import message from '../modules/responseMessage';
 import util from '../modules/util';
+import constant from '../modules/serviceReturnConstant';
 import { validationResult } from 'express-validator';
 import { MumentService } from '../services';
 import { MumentCreateDto } from '../interfaces/mument/MumentCreateDto';
@@ -107,12 +108,19 @@ const createLike = async (req: Request, res: Response) => {
     try {
         const data = await MumentService.createLike(mumentId, userId);
 
-        // 업데이트가 안됐거나, musicId가 없을 때
-        if (!data) {
-            res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST));
+        // 실패했을 때
+        switch (data) {
+            case null: {
+                // 업데이트가 실패했을 때
+                res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.CREATE_LIKE_FAIL));
+            }
+            case constant.NO_MUSIC: {
+                // 음악 data가 없을 때
+                res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_MUSIC_ID));
+            }
         }
 
-        res.status(statusCode.OK).send(util.success(statusCode.OK, message.CREATE_LIKE_SUCCESS, data));
+        res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, message.CREATE_LIKE_SUCCESS, data));
     } catch (error) {
         console.log(error);
         res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
@@ -134,7 +142,11 @@ const deleteLike = async (req: Request, res: Response) => {
     try {
         const data = await MumentService.deleteLike(mumentId, userId);
 
-        res.status(statusCode.OK).send(util.success(statusCode.OK, message.CREATE_MUMENT_SUCCESS, data));
+        if (!data) {
+            res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.DELETE_LIKE_FAIL));
+        }
+
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.DELETE_LIKE_SUCCESS, data));
 
     } catch (error) {
         console.log(error);

--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -53,7 +53,7 @@ const getMument = async (req: Request, res: Response) => {
 };
 
 /**
- * @ROUTE /mument/:userId/:musicId/history?default=
+ * @ROUTE GET /mument/:userId/:musicId/history?default=
  * @DESC get mument history
  */
 const getMumentHistory = async (req: Request, res: Response) => {
@@ -92,8 +92,60 @@ const getMumentHistory = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ * @ROUTE POST /mument/:mumentId/:userId/like
+ * @DESC 좋아요 등록
+ */
+const createLike = async (req: Request, res: Response) => {
+    const { mumentId, userId } = req.params;
+
+    const error = validationResult(req);
+    if (!error.isEmpty()) {
+        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
+    }
+
+    try {
+        const data = await MumentService.createLike(mumentId, userId);
+
+        // 업데이트가 안됐거나, musicId가 없을 때
+        if (!data) {
+            res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST));
+        }
+
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.CREATE_LIKE_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
+/**
+ * @ROUTE DELETE /mument/:mumentId/:userId/like
+ * @DESC 좋아요 취소
+ */
+const deleteLike = async (req: Request, res: Response) => {
+    const { mumentId, userId } = req.params;
+
+    const error = validationResult(req);
+    if (!error.isEmpty()) {
+        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
+    }
+
+    try {
+        const data = await MumentService.deleteLike(mumentId, userId);
+
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.CREATE_MUMENT_SUCCESS, data));
+
+    } catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 export default {
     createMument,
     getMument,
     getMumentHistory,
+    createLike,
+    deleteLike,
 };

--- a/src/interfaces/like/LikeCountResponseDto.ts
+++ b/src/interfaces/like/LikeCountResponseDto.ts
@@ -1,0 +1,6 @@
+import mongoose from 'mongoose';
+
+export interface LikeCountResponeDto {
+    mumentId: mongoose.Types.ObjectId;
+    likeCount: number;
+}

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -15,6 +15,8 @@ const message = {
     READ_MUMENT_SUCEESS: '뮤멘트 상세보기 성공',
     NOT_YOUR_MUMENT: '비밀글 입니다',
     READ_MUMENT_HISTORY_SUCCESS: '뮤멘트 히스토리 조회 성공',
+    CREATE_LIKE_SUCCESS: '좋아요 등록 성공',
+    DELETE_LIKE_SUCCESS: '좋아요 취소 성공',
 
     // music
     FIND_MUSIC_MYMUMENT_SUCCESS: '곡 상세, 나의 뮤멘트 조회 성공',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -16,6 +16,7 @@ const message = {
     NOT_YOUR_MUMENT: '비밀글 입니다',
     READ_MUMENT_HISTORY_SUCCESS: '뮤멘트 히스토리 조회 성공',
     CREATE_LIKE_SUCCESS: '좋아요 등록 성공',
+    CREATE_LIKE_FAIL: '좋아요 등록 실패',
     DELETE_LIKE_SUCCESS: '좋아요 취소 성공',
 
     // music

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -7,10 +7,13 @@ const message = {
     WRONG_PARAMS: '파라미터값이 잘못되었습니다',
 
     // user
+    NO_USER_ID: '해당 아이디의 유저가 존재하지 않습니다.',
+    NO_USER_PROFILEID: '존재하지 않는 프로필 아이디입니다',
     READ_MY_MUMENT_LIST_SUCCESS: '나의 뮤멘트 리스트 조회 성공',
     READ_LIKE_MUMENT_LIST_SUCCESS: '좋아요한 뮤멘트 리스트 조회 성공',
 
     // mument
+    NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',
     CREATE_MUMENT_SUCCESS: '뮤멘트 기록하기 성공',
     READ_MUMENT_SUCEESS: '뮤멘트 상세보기 성공',
     NOT_YOUR_MUMENT: '비밀글 입니다',
@@ -18,8 +21,10 @@ const message = {
     CREATE_LIKE_SUCCESS: '좋아요 등록 성공',
     CREATE_LIKE_FAIL: '좋아요 등록 실패',
     DELETE_LIKE_SUCCESS: '좋아요 취소 성공',
+    DELETE_LIKE_FAIL: '좋아요 취소 실패',
 
     // music
+    NO_MUSIC_ID: '해당 아이디의 음악이 존재하지 않습니다',
     FIND_MUSIC_MYMUMENT_SUCCESS: '곡 상세, 나의 뮤멘트 조회 성공',
     READ_MUSIC_MUMENTLIST_SUCCESS: '뮤멘트 리스트 조회 성공',
     SEARCH_MUSIC_LIST_SUCCESS: '곡 검색하기 성공',

--- a/src/modules/serviceReturnConstant.ts
+++ b/src/modules/serviceReturnConstant.ts
@@ -1,0 +1,11 @@
+const constant = {
+    CREATE_SUCCESS: 1, // 생성 성공
+    UPDATE_SUCCESS: 2, // 업데이트 성공
+    DELETE_SUCCESS: 3, // 삭제 성공
+
+    NO_USER: -1, // 아이디로 조회한 유저의 값이 없을 때
+    NO_MUSIC: -2, // 아이디로 조회한 음악의 값이 없을 때
+    NO_MUMENT: -3, // 아이디로 조회한 뮤멘트의 값이 없을 때
+};
+
+export default constant;

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -15,4 +15,16 @@ router.get('/:userId/:musicId/history', [
     query('default').isString().isIn(['Y', 'N']),
 ], MumentController.getMumentHistory);
 
+// 좋아요 등록
+router.post('/:mumentId/:userId/like', [
+    param('mumentId').isString().isLength({ min: 24, max: 24}),
+    param('userId').isString().isLength({ min: 24, max: 24}),
+], MumentController.createLike);
+
+// 좋아요 삭제
+router.delete('/:mumentId/:userId/like', [
+    param('mumentId').isString().isLength({ min: 24, max: 24}),
+    param('userId').isString().isLength({ min: 24, max: 24}),
+], MumentController.deleteLike);
+
 export default router;

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -6,6 +6,7 @@ const router: Router = Router();
 
 router.post('/:userId/:musicId', MumentController.createMument);
 router.get('/:mumentId/:userId', MumentController.getMument);
+router.get('/:userId/:musicId/is-first', MumentController.getIsFirst);
 
 // 히스토리 조회
 router.get('/:userId/:musicId/history', [

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -280,9 +280,7 @@ const createLike = async (mumentId: string, userId: string): Promise<LikeCountRe
         };
 
         // like 콜렉션에 해당 뮤멘트 추가
-        await Like.findOne({
-            'user._id': userId,
-        }).updateOne({}, { $push: { mument: likedMument } });
+        await Like.updateOne({ 'user._id': userId }, { $push: { mument: likedMument } }, { upsert: true });
 
         // 리턴 데이터
         const data: LikeCountResponeDto = {
@@ -309,9 +307,7 @@ const deleteLike = async (mumentId: string, userId: string): Promise<LikeCountRe
         }
 
         // like collection에서 해당 뮤멘트 삭제
-        await Like.findOne({
-            'user._id': userId,
-        }).updateOne({}, { mument: { $pull: { $elemMatch: { 'mument._id': updatedMument._id } } } } );
+        await Like.updateOne({ 'user._id': userId }, { $pull: { mument: { _id: updatedMument._id } } });
 
         // 리턴 데이터
         const data: LikeCountResponeDto = {

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -1,17 +1,18 @@
+import dayjs from 'dayjs';
+import constant from '../modules/serviceReturnConstant';
 import { MusicInfo } from '../interfaces/music/MusicInfo';
+import { PostBaseResponseDto } from '../interfaces/common/PostBaseResponseDto';
 import { MumentInfo } from '../interfaces/mument/MumentInfo';
 import { MumentCardViewInterface } from '../interfaces/mument/MumentCardViewInterface';
-import { PostBaseResponseDto } from '../interfaces/common/PostBaseResponseDto';
 import { MumentCreateDto } from '../interfaces/mument/MumentCreateDto';
 import { MumentResponseDto } from '../interfaces/mument/MumentResponseDto';
 import { MumentHistoryResponseDto } from '../interfaces/mument/MumentHistoryResponseDto';
+import { LikeCountResponeDto } from '../interfaces/like/LikeCountResponseDto';
+import { LikeMumentInfo } from '../interfaces/like/LikeInfo';
 import Mument from '../models/Mument';
 import Music from '../models/Music';
 import User from '../models/User';
 import Like from '../models/Like';
-import dayjs from 'dayjs';
-import { LikeCountResponeDto } from '../interfaces/like/LikeCountResponseDto';
-import { LikeMumentInfo } from '../interfaces/like/LikeInfo';
 
 const createMument = async (userId: string, musicId: string, mumentCreateDto: MumentCreateDto): Promise<PostBaseResponseDto | null> => {
     try {
@@ -204,7 +205,7 @@ const getMumentHistory = async (userId: string, musicId: string, isLatestOrder:b
 };
 
 // 좋아요 등록
-const createLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null> => {
+const createLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null | number> => {
     try {
         // 해당 뮤멘트의 likeCount를 +1 해주고, 업데이트 이후의 값을 리턴
         const updatedMument = await Mument.findOneAndUpdate({ _id: mumentId }, { $inc: { likeCount: +1 } }, { returnDocument: 'after' });
@@ -214,22 +215,13 @@ const createLike = async (mumentId: string, userId: string): Promise<LikeCountRe
             return null;
         }
 
-        // 지우기
-        console.log('updated mument document: ', updatedMument);
-
         // like 콜렉션에 추가하기 위해 music 정보 조회
         const music = await Music.findById(updatedMument.music._id);
 
-        /**
-         * music 정보가 없으면 return null
-         * 전체 플로우를 고려해서 로직의 필요 유무 생각해보기
-         */
+        // music 정보가 없으면 return NO_MUSIC
         if (!music) {
-            return null;
+            return constant.NO_MUSIC;
         }
-
-        // 지우기
-        console.log(music);
 
         // like 콜렉션에 추가할 뮤멘트
         const likedMument: LikeMumentInfo = {
@@ -255,7 +247,7 @@ const createLike = async (mumentId: string, userId: string): Promise<LikeCountRe
         // like 콜렉션에 해당 뮤멘트 추가
         await Like.findOne({
             'user._id': userId,
-        }).updateOne({}, { $pull: { mument: likedMument } });
+        }).updateOne({}, { $push: { mument: likedMument } });
 
         // 리턴 데이터
         const data: LikeCountResponeDto = {
@@ -271,14 +263,32 @@ const createLike = async (mumentId: string, userId: string): Promise<LikeCountRe
 };
 
 // 좋아요 취소
-const deleteLike = async (mumentId: string, userId: string) => {
+const deleteLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null | number> => {
     try {
+        // 해당 뮤멘트의 likeCount를 -1 해주고, 업데이트 이후의 값을 리턴
+        const updatedMument = await Mument.findOneAndUpdate({ _id: mumentId }, { $inc: { likeCount: -1 } }, { returnDocument: 'after' });
 
+        // 업데이트에 문제가 생겼을 경우 return null
+        if (!updatedMument) {
+            return null;
+        }
+
+        // like collection에서 해당 뮤멘트 삭제
+        await Like.findOne({
+            'user._id': userId,
+        }).updateOne({}, { mument: { $pull: { $elemMatch: { 'mument._id': updatedMument._id } } } } );
+
+        // 리턴 데이터
+        const data: LikeCountResponeDto = {
+            mumentId: updatedMument._id,
+            likeCount: updatedMument.likeCount,
+        };
+
+        return data;
     } catch (error) {
         console.log(error);
         throw error;
     }
-
 };
 
 export default {
@@ -286,5 +296,5 @@ export default {
     getMument,
     getMumentHistory,
     createLike,
-    deleteLike
+    deleteLike,
 };


### PR DESCRIPTION
## **💿 DESCRIPTION**
- service 계층에서 router 계층으로 response 상태를 주고 받기 위한 모듈 추가
### 좋아요 등록
- likeCount +1
- music 정보 조회
- 유저 아이디로 like 콜렉션에서 조회 후 mument array에 push upsert
### 좋아요 취소
- likeCount -1
- like 콜렉션에서 pull

## **🎙 RELATED ISSUE**
#21 

## **💃 REVIEW POINT**
