### PR TITLE
[FEAT] 임시 로그인 구현

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express';
 import statusCode from '../modules/statusCode';
 import message from '../modules/responseMessage';
 import util from '../modules/util';
+import constant from '../modules/serviceReturnConstant';
+import { validationResult } from 'express-validator';
 import { UserService } from '../services';
 
 /**
@@ -46,7 +48,40 @@ const getLikeMumentList = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ * @ROUTE POST /user/auth/login
+ * @DESC match user profileId and password
+ */
+const login = async (req: Request, res: Response) => {
+    const { profileId, password } = req.body;
+
+    const error = validationResult(req);
+    if (!error.isEmpty()) {
+        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_BODY));
+    }
+
+    try {
+        const data = await UserService.login(profileId, password);
+
+        // 실패했을 때
+        switch (data) {
+            case constant.NO_USER: {
+                res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NO_USER_PROFILEID));
+            };
+            case constant.WRONG_PASSWORD: {
+                res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.LOGIN_FAIL));
+            };
+        }
+
+        res.status(statusCode.OK).send(util.success(statusCode.OK, message.LOGIN_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 export default {
     getMyMumentList,
     getLikeMumentList,
+    login,
 };

--- a/src/interfaces/user/UserInfo.ts
+++ b/src/interfaces/user/UserInfo.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
 export interface UserInfo {
-    _id?: mongoose.Types.ObjectId;
+    _id: mongoose.Types.ObjectId;
     profileId: string;
     password: string;
     name: string;

--- a/src/interfaces/user/UserResponseDto.ts
+++ b/src/interfaces/user/UserResponseDto.ts
@@ -1,0 +1,8 @@
+import mongoose from 'mongoose';
+
+export interface UserResponseDto {
+    id: mongoose.Types.ObjectId;
+    profileId: string;
+    name: string;
+    image?: string;
+}

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -5,10 +5,13 @@ const message = {
     INTERNAL_SERVER_ERROR: '서버 내부 오류',
     NOT_FOUND_ID: '존재하지 않는 id 입니다',
     WRONG_PARAMS: '파라미터값이 잘못되었습니다',
+    WRONG_BODY: '바디 리퀘스트값이 잘못되었습니다',
 
     // user
     NO_USER_ID: '해당 아이디의 유저가 존재하지 않습니다.',
     NO_USER_PROFILEID: '존재하지 않는 프로필 아이디입니다',
+    LOGIN_SUCCESS: '로그인에 성공했습니다',
+    LOGIN_FAIL: '로그인에 실패했습니다',
     READ_MY_MUMENT_LIST_SUCCESS: '나의 뮤멘트 리스트 조회 성공',
     READ_LIKE_MUMENT_LIST_SUCCESS: '좋아요한 뮤멘트 리스트 조회 성공',
 

--- a/src/modules/serviceReturnConstant.ts
+++ b/src/modules/serviceReturnConstant.ts
@@ -6,6 +6,7 @@ const constant = {
     NO_USER: -1, // 아이디로 조회한 유저의 값이 없을 때
     NO_MUSIC: -2, // 아이디로 조회한 음악의 값이 없을 때
     NO_MUMENT: -3, // 아이디로 조회한 뮤멘트의 값이 없을 때
+    WRONG_PASSWORD: -4, // 패스워드가 일치하지 않을 때
 };
 
 export default constant;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -6,4 +6,10 @@ const router: Router = Router();
 router.get('/my/:userId/list', UserController.getMyMumentList);
 router.get('/like/:userId/list', UserController.getLikeMumentList);
 
+// 로그인
+router.post('/auth/longin', [
+    body('profileId').notEmpty().isString(), 
+    body('password').notEmpty().isString(),
+], UserController.login);
+
 export default router;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -6,6 +6,9 @@ import dayjs from 'dayjs';
 import Like from '../models/Like';
 import { MumentResponseDto } from '../interfaces/mument/MumentResponseDto';
 import { LikeInfo } from '../interfaces/like/LikeInfo';
+import { UserInfo } from '../interfaces/user/UserInfo';
+import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+import constant from '../modules/serviceReturnConstant';
 
 const getMyMumentList = async (userId: string): Promise<UserMumentListResponseDto | null> => {
     try {
@@ -137,7 +140,42 @@ const getLikeMumentList = async (userId: string): Promise<UserMumentListResponse
     }
 };
 
+const login = async (profileId: string, password: string): Promise<UserResponseDto | number> => {
+    try {
+        // 프로필 아이디로 다큐멘트 조회
+        const user: UserInfo | null = await User.findOne({
+            profileId: profileId,
+        });
+
+        // 프로필 아이디가 존재하지 않으면 NO_USER 리턴
+        if (!user) {
+            return constant.NO_USER;
+        }
+        
+        // 비밀번호 검증
+        const isMatch = !!(password === user.password);
+
+        // 비밀번호 틀렸을 경우
+        if (!isMatch) {
+            return constant.WRONG_PASSWORD;
+        }
+
+        const data: UserResponseDto = {
+            id: user._id,
+            profileId: user.profileId,
+            name: user.name,
+            image: user.image,
+        };
+
+        return data;
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
+
 export default {
     getMyMumentList,
     getLikeMumentList,
+    login,
 };


### PR DESCRIPTION
## **💿 DESCRIPTION**
- 프로필 아이디로 다큐멘트 조회 -> 없으면 404 에러
- 패스워드 일치 여부 판단 -> 일치하지 않으면 400 에러
- 성공하면 UserResponseDto 리턴

## **🎙 RELATED ISSUE**
#24 

## **💃 REVIEW POINT**
