### PR TITLE
[REFACTOR] 뮤멘트 상세보기 - sql query 사용 로직으로 변경 & mument/user 테이블 사용에 필요한 각종 DTO 추가

### DIFF
--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -94,7 +94,7 @@ const getMument = async (req: Request, res: Response) => {
     try {
         const data = await MumentService.getMument(mumentId, userId);
 
-        if (!data || constant.NO_MUMENT) {
+        if (!data || data === constant.NO_MUMENT) {
             res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_ID));
         } else if (data === constant.PRIVATE_MUMENT) {
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NOT_YOUR_MUMENT));

--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -94,7 +94,7 @@ const getMument = async (req: Request, res: Response) => {
     try {
         const data = await MumentService.getMument(mumentId, userId);
 
-        if (!data) {
+        if (!data || constant.NO_MUMENT) {
             res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_ID));
         } else if (data === constant.PRIVATE_MUMENT) {
             res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NOT_YOUR_MUMENT));

--- a/src/interfaces/common/NumberBaseResponseDto.ts
+++ b/src/interfaces/common/NumberBaseResponseDto.ts
@@ -1,0 +1,4 @@
+//존재 유무 파악하는 쿼리 사용시 필요한 dto
+export interface NumberBaseResponseDto {
+    exist: number;
+}

--- a/src/interfaces/mument/ExistMumentRDBDto.ts
+++ b/src/interfaces/mument/ExistMumentRDBDto.ts
@@ -1,0 +1,6 @@
+import { MumentInfoRDB } from "./MumentInfoRdb";
+
+export interface ExistMumentDto {
+    isExist: boolean;
+    mument: null | MumentInfoRDB;
+}

--- a/src/interfaces/mument/MumentInfoRDB.ts
+++ b/src/interfaces/mument/MumentInfoRDB.ts
@@ -1,0 +1,13 @@
+// RDB에서 SELECT한 mument 레코드 타입 정의
+export interface MumentInfoRDB {
+    id: number;
+    user_id: number;
+    music_id: number;
+    content: string;
+    is_first: number;
+    like_count: number;
+    is_deleted: number;
+    is_private: number;
+    created_at: Date;
+    updated_at: Date;
+}

--- a/src/interfaces/mument/MumentResponseDto.ts
+++ b/src/interfaces/mument/MumentResponseDto.ts
@@ -5,7 +5,7 @@ import { UserIdInfo } from '../user/UserInfo';
 export interface MumentResponseDto {
     _id?: mongoose.Types.ObjectId;
     user: {
-        _id: mongoose.Types.ObjectId;
+        _id: mongoose.Types.ObjectId | number;
         name: string;
         image: string;
     };
@@ -19,7 +19,7 @@ export interface MumentResponseDto {
     impressionTag: number[];
     feelingTag: number[];
     cardTag?: number[];
-    content: string;
+    content: string | null;
     isPrivate?: boolean;
     likeCount: number;
     isLiked: boolean;

--- a/src/interfaces/mument/MumentResponseDto.ts
+++ b/src/interfaces/mument/MumentResponseDto.ts
@@ -9,7 +9,7 @@ export interface MumentResponseDto {
         name: string;
         image: string;
     };
-    music: {
+    music?: {
         _id: mongoose.Types.ObjectId | null; // 보관함때문에 잠시 null
         name: string;
         artist: string;

--- a/src/interfaces/user/UserInfoRDB.ts
+++ b/src/interfaces/user/UserInfoRDB.ts
@@ -1,0 +1,10 @@
+// RDB에서 SELECT한 user 레코드 타입 정의
+export interface UserInfoRDB {
+    id: number;
+    name: string;
+    profile_id: string;
+    image: string;
+    is_deleted: number;
+    created_at: Date;
+    updated_at: Date;
+}

--- a/src/modules/db/Mument.ts
+++ b/src/modules/db/Mument.ts
@@ -1,18 +1,42 @@
-/* mument 리소스 - 재사용 쿼리 */
+/* mument 리소스 - 재사용 쿼리 - 트랜잭션 쓸 때 사용가능 */  
+import { ExistMumentDto } from "../../interfaces/mument/ExistMumentRDBDto";
 
 // 뮤멘트 태그 삽입 - impressionTag, feelingTag 리스트 합쳐서 처리
 const mumentTagCreate = async (impressionTag: number[], feelingTag: number[], connection: any, mumentId: string) => {
     const tagList = impressionTag.concat(feelingTag);
 
     for(let idx in tagList) {
-        const query4 = 'INSERT INTO mument_tag(mument_id, tag_id) VALUES(?, ?);';
-        await connection.query(query4, [
+        const query = 'INSERT INTO mument_tag(mument_id, tag_id) VALUES(?, ?);';
+        await connection.query(query, [
             mumentId,
             tagList[idx] // tag 번호
         ]);
     }
 };
 
+
+// 존재하는 뮤멘트 id인지 판단
+const isExistMument = async (mumentId: string , connection: any) => {
+    const query = 'SELECT * FROM mument WHERE id=? AND NOT is_deleted=1;'; //삭제되지 않은 뮤멘트여야 함
+    const mument: any[] = await connection.query(query, [mumentId]);
+
+    return mument.length === 0 ? false : true; // 존재하지 않으면 false 반환
+};
+
+
+// 존재하는 뮤멘트 id인지 판단 & 뮤멘트 정보 반환
+const isExistMumentInfo = async (mumentId: string , connection: any): Promise<ExistMumentDto> => {
+    const query = 'SELECT * FROM mument WHERE id=? AND NOT is_deleted=1;'; //삭제되지 않은 뮤멘트여야 함
+    const mument: any[] = await connection.query(query, [mumentId]);
+    
+    return {
+        isExist: mument.length === 0 ? false : true, // 존재하지 않으면 false
+        mument: !mument[0] ? null : mument[0] // 존재하지 않으면 null, 존재하면 뮤멘트 데이터
+    };
+};
+
 export default {
     mumentTagCreate,
+    isExistMument,
+    isExistMumentInfo,
 }

--- a/src/modules/db/Mument.ts
+++ b/src/modules/db/Mument.ts
@@ -54,8 +54,6 @@ const isLiked = async (mumentId: string, userId: string) => {
 
     // 좋아요 존재하면 1, 존재하지 않으면 0 반환함
     const isLiked: NumberBaseResponseDto[] = await pools.queryValue(query, [mumentId, userId]);
-    console.log(isLiked);
-    //console.log(isLiked.exist);
 
     return isLiked[0].exist;
 };

--- a/src/modules/db/Mument.ts
+++ b/src/modules/db/Mument.ts
@@ -59,9 +59,58 @@ const isLiked = async (mumentId: string, userId: string) => {
 };
 
 
+// 뮤멘트의 좋아요 개수 count
+const likeCount = async (mumentId: string) => {
+    const query = `SELECT COUNT(*) as exist FROM mument.like WHERE mument_id=${mumentId};`;
+
+    const likeCount: NumberBaseResponseDto[] = await pools.query(query);
+
+    return likeCount[0].exist;
+};
+
+
+// 사용자의 뮤멘트 히스토리 개수 count
+const mumentHistoryCount = async (musicId: string, userId: string) => {
+    // 삭제되지않고 & 비밀글이 아닌 뮤멘트 개수
+    const query = 'SELECT COUNT(*) as exist FROM mument WHERE music_id=? AND user_id=? AND NOT is_deleted=1 AND NOT is_private=1;';
+
+    const historyCount: NumberBaseResponseDto[] = await pools.queryValue(query, [musicId, userId]);
+
+    return historyCount[0].exist;
+};
+
+
+// 뮤멘트의 태그 검색해서 impressionTag, feelingTag 리스트로 반환
+const mumentTagListGet = async (mumentId: string) => {
+    // 뮤멘트의 태그 모두 검색
+    const query = `SELECT tag_id as exist FROM mument_tag WHERE mument_id=${mumentId};`;
+
+    const tagList: NumberBaseResponseDto[] = await pools.query(query);
+    
+    let impressionTag: number[] = [], feelingTag: number[] = [];
+
+    // 100이상 200미만 - impression tag, 200이상 300미만 - feeling tag
+    for (let idx in tagList) {
+        if (tagList[idx].exist < 200) {
+            impressionTag.push(tagList[idx].exist);
+        } else if (tagList[idx].exist < 300) {
+            feelingTag.push(tagList[idx].exist);
+        }
+    }
+
+    return {
+        impressionTag: impressionTag,
+        feelingTag: feelingTag
+    };
+};
+
+
 export default {
     mumentTagCreate,
     isExistMument,
     isExistMumentInfo,
     isLiked,
+    likeCount,
+    mumentHistoryCount,
+    mumentTagListGet,
 }

--- a/src/modules/db/Mument.ts
+++ b/src/modules/db/Mument.ts
@@ -1,5 +1,12 @@
-/* mument 리소스 - 재사용 쿼리 - 트랜잭션 쓸 때 사용가능 */  
 import { ExistMumentDto } from "../../interfaces/mument/ExistMumentRDBDto";
+import { NumberBaseResponseDto } from "../../interfaces/common/NumberBaseResponseDto";
+import pools from '../pool';
+import { MumentInfoRDB } from "../../interfaces/mument/MumentInfoRdb";
+
+/**
+ * mument 관련 재사용 쿼리 - 트랜잭션 쓸 때 사용가능
+ */
+
 
 // 뮤멘트 태그 삽입 - impressionTag, feelingTag 리스트 합쳐서 처리
 const mumentTagCreate = async (impressionTag: number[], feelingTag: number[], connection: any, mumentId: string) => {
@@ -18,7 +25,7 @@ const mumentTagCreate = async (impressionTag: number[], feelingTag: number[], co
 // 존재하는 뮤멘트 id인지 판단
 const isExistMument = async (mumentId: string , connection: any) => {
     const query = 'SELECT * FROM mument WHERE id=? AND NOT is_deleted=1;'; //삭제되지 않은 뮤멘트여야 함
-    const mument: any[] = await connection.query(query, [mumentId]);
+    const mument: MumentInfoRDB[] = await connection.query(query, [mumentId]);
 
     return mument.length === 0 ? false : true; // 존재하지 않으면 false 반환
 };
@@ -27,7 +34,7 @@ const isExistMument = async (mumentId: string , connection: any) => {
 // 존재하는 뮤멘트 id인지 판단 & 뮤멘트 정보 반환
 const isExistMumentInfo = async (mumentId: string , connection: any): Promise<ExistMumentDto> => {
     const query = 'SELECT * FROM mument WHERE id=? AND NOT is_deleted=1;'; //삭제되지 않은 뮤멘트여야 함
-    const mument: any[] = await connection.query(query, [mumentId]);
+    const mument: MumentInfoRDB[] = await connection.query(query, [mumentId]);
     
     return {
         isExist: mument.length === 0 ? false : true, // 존재하지 않으면 false
@@ -35,8 +42,28 @@ const isExistMumentInfo = async (mumentId: string , connection: any): Promise<Ex
     };
 };
 
+
+
+/**
+ * mument관련 재사용 쿼리 - 트랜잭션 없이 사용가능
+ */
+
+// userId가 해당 뮤멘트에 좋아요를 눌렀는지 확인
+const isLiked = async (mumentId: string, userId: string) => {
+    const query = 'SELECT EXISTS(SELECT * FROM mument.like WHERE mument_id=? AND user_id=?) as exist;';
+
+    // 좋아요 존재하면 1, 존재하지 않으면 0 반환함
+    const isLiked: NumberBaseResponseDto[] = await pools.queryValue(query, [mumentId, userId]);
+    console.log(isLiked);
+    //console.log(isLiked.exist);
+
+    return isLiked[0].exist;
+};
+
+
 export default {
     mumentTagCreate,
     isExistMument,
     isExistMumentInfo,
+    isLiked,
 }

--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -1,0 +1,26 @@
+import { UserInfoRDB } from '../../interfaces/user/UserInfoRDB';
+import pools from '../pool';
+
+/**
+ * user 관련 재사용 쿼리 - 트랜잭션 쓸 때 사용가능
+ */
+
+
+
+/**
+ * user 관련 재사용 쿼리 - 트랜잭션 없이 사용가능
+ */
+
+// userId로 유저 레코드 가져오기
+const userInfo = async (userId: string) => {
+    const query = 'SELECT * FROM user WHERE id=? AND NOT is_deleted=1'; //탈퇴하지 않은 유저
+    
+    const user: UserInfoRDB[] = await pools.queryValue(query, [userId]);
+
+    return user[0];
+}
+
+export default {
+    userInfo,
+}
+

--- a/src/modules/pool.ts
+++ b/src/modules/pool.ts
@@ -5,7 +5,7 @@ import poolPromise from '../loaders/db';
  */
 
 // 완성된 query만 받을 시
-const query = async (query: string) => {
+const query = async (query: string): Promise<any[]> => {
     return new Promise ( async (resolve, reject) => {
         try {
             //Connection Pool 생성
@@ -34,7 +34,7 @@ const query = async (query: string) => {
 };
 
 // // query에 필요한 value를 따로 받을 시 
-const queryValue = async (query: string, value: any) => {
+const queryValue = async (query: string, value: any): Promise<any[]> => {
     return new Promise(async (resolve, reject) => {
         try {
             //Connection Pool 생성

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -8,8 +8,6 @@ router.post('/:userId/:musicId', MumentController.createMument);
 
 router.put('/:mumentId', [
     body('isFirst').notEmpty(),
-    body('impressionTag').notEmpty(),
-    body('feelingTag').notEmpty(),
 ], MumentController.updateMument);
 router.get('/:mumentId/:userId', MumentController.getMument);
 router.get('/:userId/:musicId/is-first', MumentController.getIsFirst);

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -90,8 +90,9 @@ const appleSignIn = async (authorization_code: string, identity_token: string): 
             
         //     return data; 
         // }
-        // // id가 존재하지 않으면
-        // return constant.NO_IDENTITY_TOKEN_SUB;
+        
+        // id가 존재하지 않으면
+        return constant.NO_IDENTITY_TOKEN_SUB;
     } catch (error) {
         console.log(error);
         throw error;

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -36,6 +36,7 @@ import { Connection } from 'promise-mysql';
 import { StringBaseResponseDto } from '../interfaces/common/StringBaseResponseDto';
 import mumentDB from '../modules/db/Mument';
 import { ExistMumentDto } from '../interfaces/mument/ExistMumentRDBDto';
+import { MumentInfoRDB } from '../interfaces/mument/MumentInfoRdb';
 
 /** 
  * 뮤멘트 기록하기
@@ -132,14 +133,14 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
     try {
         // 존재하지 않는 id의 뮤멘트를 수정하려고 할 때
         const isExistMumentInfo: ExistMumentDto = await mumentDB.isExistMumentInfo(mumentId, connection);
+        
         if (isExistMumentInfo.isExist === false) return constant.NO_MUMENT;
-        console.log(isExistMumentInfo.mument);
 
-        const mument = isExistMumentInfo.mument; // 뮤멘트 데이터 가져오기
-    
+        const mument = isExistMumentInfo.mument as MumentInfoRDB; // 뮤멘트 데이터 가져오기
+
         //  비밀글인데, 본인의 뮤멘트가 아닐 경우 -> 조회하지 못하도록
-        if (mument?.is_private === 1 && mument.user_id.toString() !== userId) return constant.PRIVATE_MUMENT;
-
+        if (mument.is_private === 1 && mument.user_id.toString() !== userId) return constant.PRIVATE_MUMENT;
+        
         // // to-do: 사용자가 이 뮤멘트에 좋아요 눌렀는지
         // const isLiked = false;
         // // const isLiked = await Like.findOne({

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -140,19 +140,11 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
 
         //  비밀글인데, 본인의 뮤멘트가 아닐 경우 -> 조회하지 못하도록
         if (mument.is_private === 1 && mument.user_id.toString() !== userId) return constant.PRIVATE_MUMENT;
+
+
+        // 사용자가 이 뮤멘트에 좋아요 눌렀으면 1, 아니면 0
+        const isLiked = await mumentDB.isLiked(mumentId, userId);
         
-        // // to-do: 사용자가 이 뮤멘트에 좋아요 눌렀는지
-        // const isLiked = false;
-        // // const isLiked = await Like.findOne({
-        // //     $and: [
-        // //         {
-        // //             mument: { $elemMatch: { _id: mumentId } },
-        // //         },
-        // //         {
-        // //             'user._id': { $eq: userId },
-        // //         },
-        // //     ],
-        // // });
 
         // // to-do: 뮤멘트 히스토리 개수 - 뮤멘트의 작성자가 해당 곡에 쓴 뮤멘트 개수 : 조건 추가사항 - isDeleted와 isPrivate가 false이어야함
         // const historyCount = 0;
@@ -180,7 +172,7 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
         //     feelingTag: mument.feelingTag,
         //     content: mument.content,
         //     likeCount: mument.likeCount,
-        //     isLiked: !isLiked ? false : true,
+        //     isLiked: Boolean(isLiked), //수정완
         //     createdAt: createdTime,
         //     count: historyCount,
         // };

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -32,11 +32,12 @@ import AgainSelection from '../models/AgainSelection';
 import dummyData from '../modules/dummyData'; // 임시 더미 데이터
 import pools from '../modules/pool';
 import poolPromise from '../loaders/db';
-import { Connection } from 'promise-mysql';
 import { StringBaseResponseDto } from '../interfaces/common/StringBaseResponseDto';
 import mumentDB from '../modules/db/Mument';
+import userDB from '../modules/db/User';
 import { ExistMumentDto } from '../interfaces/mument/ExistMumentRDBDto';
 import { MumentInfoRDB } from '../interfaces/mument/MumentInfoRdb';
+import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
 
 /** 
  * 뮤멘트 기록하기
@@ -141,9 +142,11 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
         //  비밀글인데, 본인의 뮤멘트가 아닐 경우 -> 조회하지 못하도록
         if (mument.is_private === 1 && mument.user_id.toString() !== userId) return constant.PRIVATE_MUMENT;
 
-
         // 사용자가 이 뮤멘트에 좋아요 눌렀으면 1, 아니면 0
         const isLiked = await mumentDB.isLiked(mumentId, userId);
+
+        // 사용자 정보 가져오기
+        const user = await userDB.userInfo(userId);
         
 
         // // to-do: 뮤멘트 히스토리 개수 - 뮤멘트의 작성자가 해당 곡에 쓴 뮤멘트 개수 : 조건 추가사항 - isDeleted와 isPrivate가 false이어야함
@@ -163,9 +166,9 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
 
         // const data: MumentResponseDto = {
         //     user: {
-        //         _id: mument.user._id,
-        //         image: mument.user.image,
-        //         name: mument.user.name,
+        //         _id: user.id, //수정완
+        //         image: user.image, //수정완
+        //         name: user.profile_id, //수정완
         //     },
         //     isFirst: mument.isFirst,
         //     impressionTag: mument.impressionTag,

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -35,6 +35,7 @@ import poolPromise from '../loaders/db';
 import { Connection } from 'promise-mysql';
 import { StringBaseResponseDto } from '../interfaces/common/StringBaseResponseDto';
 import mumentDB from '../modules/db/Mument';
+import { ExistMumentDto } from '../interfaces/mument/ExistMumentRDBDto';
 
 /** 
  * 뮤멘트 기록하기
@@ -84,12 +85,9 @@ const updateMument = async (mumentId: string, mumentUpdateDto: MumentCreateDto):
     try {
         await connection.beginTransaction(); // 트랜잭션 적용 시작
 
-        // 쿼리 : 뮤멘트 존재하는지 확인
-        const query1 = 'SELECT * FROM mument WHERE id=?;'
-        const mument: any = await pools.queryValue(query1, [mumentId]);
-
         // 존재하지 않는 id의 뮤멘트를 수정하려고 할 때
-        if (mument.length===0) return constant.NO_MUMENT;
+        const isExistMument: boolean = await mumentDB.isExistMument(mumentId, connection);
+        if (isExistMument===false) return constant.NO_MUMENT;
 
         //뮤멘트 수정사항 update
         const query2 = 'UPDATE mument SET is_first=?, content=?, is_private=? WHERE id=?;';
@@ -128,76 +126,74 @@ const updateMument = async (mumentId: string, mumentUpdateDto: MumentCreateDto):
  * 뮤멘트 상세보기
  */
 const getMument = async (mumentId: string, userId: string): Promise<MumentResponseDto | null | number> => {
+    const pool: any = await poolPromise;
+    const connection = await pool.getConnection();
+    
     try {
-        /**
-        * ✅몽고디비 연결 임시 주석처리 + 변수에 임시로 더미 넣어둠
-        */       
-        const mument = dummyData.mumentDummy;
-        // const mument = await Mument.findById(mumentId);
-        if (!mument) return null;
+        // 존재하지 않는 id의 뮤멘트를 수정하려고 할 때
+        const isExistMumentInfo: ExistMumentDto = await mumentDB.isExistMumentInfo(mumentId, connection);
+        if (isExistMumentInfo.isExist === false) return constant.NO_MUMENT;
+        console.log(isExistMumentInfo.mument);
 
-        const loginUser = dummyData.userDummy;
-        // const loginUser = await User.findById(userId);
-        if (!loginUser) return null;
+        const mument = isExistMumentInfo.mument; // 뮤멘트 데이터 가져오기
+    
+        //  비밀글인데, 본인의 뮤멘트가 아닐 경우 -> 조회하지 못하도록
+        if (mument?.is_private === 1 && mument.user_id.toString() !== userId) return constant.PRIVATE_MUMENT;
 
-        if (mument.isPrivate === true && mument.user._id.toString() !== userId) return constant.PRIVATE_MUMENT;
+        // // to-do: 사용자가 이 뮤멘트에 좋아요 눌렀는지
+        // const isLiked = false;
+        // // const isLiked = await Like.findOne({
+        // //     $and: [
+        // //         {
+        // //             mument: { $elemMatch: { _id: mumentId } },
+        // //         },
+        // //         {
+        // //             'user._id': { $eq: userId },
+        // //         },
+        // //     ],
+        // // });
 
-        const music = dummyData.musicDummy;
-        // const music = await Music.findById(mument.music._id);
-        if (!music) return null;
+        // // to-do: 뮤멘트 히스토리 개수 - 뮤멘트의 작성자가 해당 곡에 쓴 뮤멘트 개수 : 조건 추가사항 - isDeleted와 isPrivate가 false이어야함
+        // const historyCount = 0;
+        // // const historyCount = await Mument.countDocuments({
+        // //     $and: [
+        // //         {
+        // //             'music._id': { $eq: mument.music._id },
+        // //         },
+        // //         {
+        // //             'user._id': { $eq: mument.user._id },
+        // //         },
+        // //     ],
+        // // });
 
-        const isLiked = false;
-        // const isLiked = await Like.findOne({
-        //     $and: [
-        //         {
-        //             mument: { $elemMatch: { _id: mumentId } },
-        //         },
-        //         {
-        //             'user._id': { $eq: userId },
-        //         },
-        //     ],
-        // });
+        // const createdTime = dayjs(mument.createdAt).format('YYYY.MM.DD h:mm A');
 
-        const historyCount = 0;
-        // const historyCount = await Mument.countDocuments({
-        //     $and: [
-        //         {
-        //             'music._id': { $eq: mument.music._id },
-        //         },
-        //         {
-        //             'user._id': { $eq: mument.user._id },
-        //         },
-        //     ],
-        // });
+        // const data: MumentResponseDto = {
+        //     user: {
+        //         _id: mument.user._id,
+        //         image: mument.user.image,
+        //         name: mument.user.name,
+        //     },
+        //     isFirst: mument.isFirst,
+        //     impressionTag: mument.impressionTag,
+        //     feelingTag: mument.feelingTag,
+        //     content: mument.content,
+        //     likeCount: mument.likeCount,
+        //     isLiked: !isLiked ? false : true,
+        //     createdAt: createdTime,
+        //     count: historyCount,
+        // };
 
-        const createdTime = dayjs(mument.createdAt).format('YYYY.MM.DD h:mm A');
+        await connection.commit(); // query1, query2 모두 성공시 커밋(데이터 적용)
 
-        const data: MumentResponseDto = {
-            user: {
-                _id: mument.user._id,
-                image: mument.user.image,
-                name: mument.user.name,
-            },
-            music: {
-                _id: mument.music._id,
-                name: music.name,
-                artist: music.artist,
-                image: music.image,
-            },
-            isFirst: mument.isFirst,
-            impressionTag: mument.impressionTag,
-            feelingTag: mument.feelingTag,
-            content: mument.content,
-            likeCount: mument.likeCount,
-            isLiked: !isLiked ? false : true,
-            createdAt: createdTime,
-            count: historyCount,
-        };
-
+        const data = null;
         return data;
     } catch (error) {
         console.log(error);
+        await connection.rollback(); // query1, query2 중 하나라도 에러시 롤백 (데이터 적용 원상복귀)
         throw error;
+    } finally {
+        connection.release(); // pool connection 회수
     }
 };
 


### PR DESCRIPTION
## **💿 DESCRIPTION**
뮤멘트 상세보기 SQL사용으로 리팩토링
- 비밀글일 때 → 본인의 글이 아닐 경우 못보도록:  400 보내도록
- 존재하지않는 뮤멘트 id면(갑자기 유저가 삭제했을수도?) - id없다고하기  -> 모듈로 뺌
- 뮤멘트 작성자 정보 검색 -> 모듈로 뺌
- 좋아요 유무 검색 -> 모듈로 뺌
- 뮤멘트 히스토리 개수 -> 모듈로 뺌
- impressionTag, feelingTag 검색 -> 모듈로 뺌


## **🎙 RELATED ISSUE**
#73 

## **💃 REVIEW POINT**
- 뮤멘트 상세보기 리팩토링하다보니 모든 API에서 공통으로 쓰는 쿼리처리 과정이 나타나서 모두 modules/db/Mument.ts 와 modules/db/User.ts에 함수 분리했습니다!
그리고 트랜잭션필요한 경우에 쓰는 함수들과 바로 쿼리를 쓰는 경우의 함수들을 주석으로 경계를 지어놨는데...아마도 더 좋은 방법이 있을 것 같으나 저의 최선이었습니다ㅜ_ㅜ

- 새로운 DTO들이 많이 있습니다 대부분 헷갈릴까봐 상단에 주석을 일단 달아두었습니다!!!  RDB에서 mument와 user select했을 때의 형태는 MumentInfoRDB, UserInfoRDB 파일로 만들어두었습니다!!
