### PR TITLE
[REFACTOR] 보관함 내가 작성한 뮤멘트 리스트 - sql query 사용 로직으로 변경

### DIFF
--- a/src/interfaces/mument/MumentResponseDto.ts
+++ b/src/interfaces/mument/MumentResponseDto.ts
@@ -3,21 +3,21 @@ import { MusicInfo } from '../music/MusicInfo';
 import { UserIdInfo } from '../user/UserInfo';
 
 export interface MumentResponseDto {
-    _id?: mongoose.Types.ObjectId;
+    _id?: mongoose.Types.ObjectId | number;
     user: {
         _id: mongoose.Types.ObjectId | number;
         name: string;
         image: string;
     };
     music?: {
-        _id: mongoose.Types.ObjectId | null; // 보관함때문에 잠시 null
+        _id: mongoose.Types.ObjectId | null | number; // 보관함때문에 잠시 null
         name: string;
         artist: string;
         image: string;
     };
     isFirst: boolean;
-    impressionTag: number[];
-    feelingTag: number[];
+    impressionTag?: number[];
+    feelingTag?: number[];
     cardTag?: number[];
     content: string | null;
     isPrivate?: boolean;

--- a/src/interfaces/mument/MumentResponseDto.ts
+++ b/src/interfaces/mument/MumentResponseDto.ts
@@ -18,7 +18,8 @@ export interface MumentResponseDto {
     isFirst: boolean;
     impressionTag?: number[];
     feelingTag?: number[];
-    cardTag?: number[];
+    allCardTag?: number[]; // 전체 뮤멘트 태그 리스트 - 보관함때문에 추가
+    cardTag?: number[]; // 뮤멘트 카드에 띄우는 최대 2개의 태그 리스트
     content: string | null;
     isPrivate?: boolean;
     likeCount: number;

--- a/src/interfaces/mument/MyMumentInfoRDB.ts
+++ b/src/interfaces/mument/MyMumentInfoRDB.ts
@@ -5,11 +5,14 @@ export interface MyMumentInfoRDB {
     user_id: number;
     music_id: number;
     is_first: boolean;
+    content: string;
     like_count: number;
     is_private: boolean;
     created_at: Date; // 뮤멘트 작성일
     artist: string; // 곡 아티스트
-    iamge: string; //곡 이미지
+    music_image: string; //곡 이미지
     name: string; //곡 제목
-    tag_id: number; //태그 번호
+    tag_id: number; //태그 번호;
+    profile_id?: string; // 유저 프로필 이름
+    user_image?: string; // 유저 프로필 이미지
 }

--- a/src/interfaces/mument/MyMumentInfoRDB.ts
+++ b/src/interfaces/mument/MyMumentInfoRDB.ts
@@ -1,0 +1,15 @@
+// RDB에서 mument, music, mument_tag를 JOIN해서 SELECT한 레코드 타입 정의
+// 보관함 - 내가 작성한 뮤멘트 리스트에서 사용
+export interface MyMumentInfoRDB {
+    mument_id: number;
+    user_id: number;
+    music_id: number;
+    is_first: boolean;
+    like_count: number;
+    is_private: boolean;
+    created_at: Date; // 뮤멘트 작성일
+    artist: string; // 곡 아티스트
+    iamge: string; //곡 이미지
+    name: string; //곡 제목
+    tag_id: number; //태그 번호
+}

--- a/src/interfaces/music/MusicInfoRDB.ts
+++ b/src/interfaces/music/MusicInfoRDB.ts
@@ -1,0 +1,7 @@
+// RDB에서 SELECT한 music 레코드 타입 정의
+export interface MusicInfoRDB {
+    id: number;
+    artist: string;
+    image: string;
+    name: string;
+}

--- a/src/interfaces/user/UserInfoRDB.ts
+++ b/src/interfaces/user/UserInfoRDB.ts
@@ -1,7 +1,7 @@
 // RDB에서 SELECT한 user 레코드 타입 정의
 export interface UserInfoRDB {
     id: number;
-    name: string;
+    name?: string;
     profile_id: string;
     image: string;
     is_deleted: number;

--- a/src/modules/db/Mument.ts
+++ b/src/modules/db/Mument.ts
@@ -104,6 +104,8 @@ const mumentTagListGet = async (mumentId: string) => {
     };
 };
 
+// 뮤멘트 id에 해당하는 태그 리스트로 반환하기
+
 
 export default {
     mumentTagCreate,

--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -1,5 +1,8 @@
 import { UserInfoRDB } from '../../interfaces/user/UserInfoRDB';
 import pools from '../pool';
+import { MumentInfoRDB } from "../../interfaces/mument/MumentInfoRdb";
+import mumentDB from './Mument';
+import { MyMumentInfoRDB } from '../../interfaces/mument/MyMumentInfoRDB';
 
 /**
  * user 관련 재사용 쿼리 - 트랜잭션 쓸 때 사용가능
@@ -20,7 +23,37 @@ const userInfo = async (userId: string) => {
     return user[0];
 }
 
+// 내가 작성한 뮤멘트 리스트 가져오기 - 최신순
+const myMumentList = async (userId: string) => {
+    interface mumentAndLikeInfo {
+        mument: MyMumentInfoRDB;
+        LikeCount: number;
+    }
+    let myMumentLikeCountList = [];
+
+    // mument & mument tag & music 테이블 조인
+    const mumentListQuery = `
+        SELECT mument.id as mument_id, user_id,
+            music_id, is_first, like_count,
+            is_private, mument.created_at as created_at,
+            artist, image, name, tag_id
+            FROM mument
+            JOIN music
+            ON mument.music_id = music.id
+            JOIN mument_tag
+            ON mument.id = mument_tag.mument_id
+            WHERE user_id=${userId} AND mument.is_deleted=0
+            ORDER BY mument.created_at DESC;`;
+    
+    const myMumentList: MyMumentInfoRDB[] = await pools.query(mumentListQuery);
+    console.log(myMumentList);
+
+    return myMumentList;
+};
+
+
 export default {
     userInfo,
+    myMumentList
 }
 

--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -43,6 +43,29 @@ const myMumentList = async (userId: string) => {
     return myMumentList;
 };
 
+// 좋아요한 뮤멘트 리스트 가져오기 - 최신순
+const myLikeMumentList = async (userId: string) => {
+    const mumentListQuery = `
+        SELECT mument.id as mument_id, user_id,
+            music_id, is_first, like_count, content,
+            is_private, mument.created_at as created_at,
+            artist, music.image as music_image, name, tag_id,
+            profile_id, user.image as user_image
+            FROM mument
+            JOIN music
+            ON mument.music_id = music.id
+            JOIN mument_tag
+            ON mument.id = mument_tag.mument_id
+            JOIN user
+            ON mument.user_id = user.id
+            WHERE user_id=${userId} AND mument.is_deleted=0
+            ORDER BY mument.created_at DESC;`;
+    
+    const myMumentList: MyMumentInfoRDB[] = await pools.query(mumentListQuery);
+
+    return myMumentList;
+};
+
 
 export default {
     userInfo,

--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -26,17 +26,11 @@ const userInfo = async (userId: string) => {
 // 내가 작성한 뮤멘트 리스트 가져오기 - 최신순
 const myMumentList = async (userId: string) => {
     interface mumentAndLikeInfo {
-        mument: MyMumentInfoRDB;
-        LikeCount: number;
-    }
-    let myMumentLikeCountList = [];
-
-    // mument & mument tag & music 테이블 조인
     const mumentListQuery = `
         SELECT mument.id as mument_id, user_id,
-            music_id, is_first, like_count,
+            music_id, is_first, like_count, content,
             is_private, mument.created_at as created_at,
-            artist, image, name, tag_id
+            artist, music.image as music_image, name, tag_id
             FROM mument
             JOIN music
             ON mument.music_id = music.id
@@ -46,7 +40,6 @@ const myMumentList = async (userId: string) => {
             ORDER BY mument.created_at DESC;`;
     
     const myMumentList: MyMumentInfoRDB[] = await pools.query(mumentListQuery);
-    console.log(myMumentList);
 
     return myMumentList;
 };

--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -25,7 +25,6 @@ const userInfo = async (userId: string) => {
 
 // 내가 작성한 뮤멘트 리스트 가져오기 - 최신순
 const myMumentList = async (userId: string) => {
-    interface mumentAndLikeInfo {
     const mumentListQuery = `
         SELECT mument.id as mument_id, user_id,
             music_id, is_first, like_count, content,

--- a/src/modules/db/cardTagList.ts
+++ b/src/modules/db/cardTagList.ts
@@ -32,8 +32,6 @@ const cardTag  = async (tagList: number[]) => { //인자로 뮤멘트의 전체 
         // 감정 태그만 존재 시 - 감정태그만 최대 2개 삽입
         cardTag.push(...feelingTag.slice(0, 2));
     }
-    console.log('인상태그 ', impressionTag);
-    console.log('감정태그 ', feelingTag);
 
     return cardTag;
 };

--- a/src/modules/db/cardTagList.ts
+++ b/src/modules/db/cardTagList.ts
@@ -1,0 +1,43 @@
+/**
+ * 뮤멘트 카드뷰에 띄우는 태그 리스트 만드는 모듈 - 최대 2개를 띄우되 감정, 인상 태그가 섞여있으면 1개씩 넣도록함
+ * : 감정 태그 1, 인상 태그1 or 인상 태그 2 or 감정 태그 2 or 1개 이하는 존재하는 태그 넣도록
+ * 
+ */
+
+const cardTag  = async (tagList: number[]) => { //인자로 뮤멘트의 전체 태그 리스트를 넘겨주면 됨
+    let impressionTag: number[] = [], feelingTag: number[] = [];
+    let impressionTagLength: number;
+    let feelingTagLength: number;
+    const cardTag: number[] = [];
+
+    // 100이상 200미만 - impression tag, 200이상 300미만 - feeling tag
+    for (let idx in tagList) {
+        if (tagList[idx] < 200) {
+            impressionTag.push(tagList[idx]);
+        } else if (tagList[idx] < 300) {
+            feelingTag.push(tagList[idx]);
+        }
+    }
+    
+    impressionTagLength = impressionTag.length;
+    feelingTagLength = feelingTag.length;
+
+    if (impressionTagLength >= 1 && feelingTagLength >= 1) {
+        // 인상, 감정 태그 둘다 존재 시 - 1개씩 삽입
+        cardTag.push(impressionTag[0], feelingTag[0]);
+    } else if (impressionTagLength >= 1 && feelingTagLength < 1) {
+        // 인상 태그만 존재 시 - 인상태그만 최대 2개 삽입
+        cardTag.push(...impressionTag.slice(0, 2));
+    } else if (impressionTagLength < 1 && feelingTagLength >= 1) {
+        // 감정 태그만 존재 시 - 감정태그만 최대 2개 삽입
+        cardTag.push(...feelingTag.slice(0, 2));
+    }
+    console.log('인상태그 ', impressionTag);
+    console.log('감정태그 ', feelingTag);
+
+    return cardTag;
+};
+
+export default {
+    cardTag
+}

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import { UserMumentListResponseDto } from '../interfaces/user/UserMumentListResponseDto';
 import { MumentResponseDto } from '../interfaces/mument/MumentResponseDto';
-import { UserResponseDto } from '../interfaces/user/UserResponseDto';
 import { LikeInfo } from '../interfaces/like/LikeInfo';
 import { MumentInfo } from '../interfaces/mument/MumentInfo';
 import { UserInfo } from '../interfaces/user/UserInfo';
@@ -12,115 +11,85 @@ import User from '../models/User';
 import constant from '../modules/serviceReturnConstant';
 import dummyData from '../modules/dummyData';
 import pools from '../modules/pool';
+import { MumentInfoRDB } from '../interfaces/mument/MumentInfoRdb';
+import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
+import mumentDB from '../modules/db/Mument';
+import userDB from '../modules/db/User';
+import { MyMumentInfoRDB } from '../interfaces/mument/MyMumentInfoRDB';
+
 /**
  * 내가 작성한 뮤멘트 리스트
  */
 const getMyMumentList = async (userId: string, tagList: number[]): Promise<UserMumentListResponseDto | null> => {
     try {
-        // // ✅ mySql connection query 테스트 - 후에 삭제
-        // const query = 'SELECT * FROM user';
-        // const result = await pools.query(query);
-        // ✅ mySql connection queryValue 테스트 - 후에 삭제
-        // const query2= 'INSERT INTO user(name, profile_id, image) VALUES (?, ?, ?)';
-        // await pools.queryValue(query2, ['쿼리테스트유저', 'querytestuser', 'http'])
+        // 내가 작성한 뮤멘트 리스트&음악 정보 가져오기
+        let myMumentList: MyMumentInfoRDB[] = await userDB.myMumentList(userId);
+        if (myMumentList.length === 0) return {muments: []};
 
-        /**
-         * ✅몽고디비 연결 임시 주석처리 + 변수에 임시로 더미 넣어둠
-         */
-        let myMumentList = [dummyData.mumentDummy, dummyData.mumentDummy];
-        // let myMumentList: MumentInfo[] = await Mument.find({
-        //     $and: [
-        //         {
-        //             'user._id': { $eq: userId },
-        //         },
-        //         {
-        //             isDeleted: { $eq: false },
-        //         },
-        //     ],
-        // }).sort({ createdAt: -1 });
+        let result: MumentResponseDto[] = [];
 
-        if (!myMumentList) {
-            return {
-                muments: [],
-            };
-        }
+        // for문을 통해 하나의 뮤멘트에 대해 tag 합칠 배열
+        let cardTagList: number[] = []
 
-        // 필터링 태그 존재시 뮤멘트 필터링
+        // 나의 유저 정보
+        const user = await userDB.userInfo(myMumentList[0].user_id.toString());
+
+        const myMumentListFunc = async (item: MyMumentInfoRDB, idx: number) => {
+            if (idx === myMumentList.length - 1 || (idx < myMumentList.length - 1 && myMumentList[idx + 1].mument_id !== item.mument_id)) {
+                
+                // isLiked 좋아요 유무
+                const isLiked = await mumentDB.isLiked(item.mument_id.toString(), item.user_id.toString());
+                // 뮤멘트 태그 합치기
+                cardTagList.push(item.tag_id);
+                // 태그 리스트 3개 이하로 자르기
+                cardTagList = cardTagList.slice(0, 3);
+
+                result.push({
+                    _id: item.mument_id,
+                    user: {
+                        _id: item.user_id,
+                        image: user.image,
+                        name: user.profile_id
+                    },
+                    music: {
+                        _id: item.music_id,
+                        name: item.name,
+                        artist: item.artist,
+                        image: item.music_image
+                    },
+                    isFirst: Boolean(item.is_first),
+                    cardTag: cardTagList,
+                    content: item.content,
+                    isPrivate: Boolean(item.is_private),
+                    likeCount: item.like_count,
+                    isLiked: Boolean(isLiked),
+                    createdAt: dayjs(item.created_at).format('D MMM, YYYY'),
+                    year: Number(dayjs(item.created_at).format('YYYY')),
+                    month: Number(dayjs(item.created_at).format('M'))
+                });
+                cardTagList = []; // 리셋
+            } else {
+                
+                // 뮤멘트 태그 합치기
+                cardTagList.push(item.tag_id);
+            }
+        };
+
+        await myMumentList.reduce(async (pre, curr, index) => {
+                return pre.then(() => myMumentListFunc(curr, index));
+        }, Promise.resolve());
+
+        // 필링 태그 존재시 뮤멘트 필터링
         if (tagList.length > 0) {
-            myMumentList = myMumentList.filter(mument => {
-                const mumentTagList = mument.impressionTag.concat(mument.feelingTag);
-
+            result = result.filter(mument => {
                 return tagList.every(tag => {
-                    return mumentTagList.includes(tag);
+                    return mument.cardTag?.includes(tag);
                 });
             });
         }
 
-        const data = await Promise.all(
-            myMumentList.map(async (mument: any) => {
-                /**
-                * ✅몽고디비 연결 임시 주석처리 + 변수에 임시로 더미 넣어둠
-                */
-                const music = dummyData.musicDummy;
-                //const music = await Music.findById(mument.music._id);
-
-                const isLiked = false;
-                // const isLiked = await Like.findOne({
-                //     $and: [
-                //         {
-                //             mument: { $elemMatch: { _id: mument._id } },
-                //         },
-                //         {
-                //             'user._id': { $eq: userId },
-                //         },
-                //     ],
-                // });
-
-                // 카드뷰 태그 리스트
-                const cardTag: number[] = [];
-                const impressionTagLength = mument.impressionTag.length;
-                const feelingTagLength = mument.feelingTag.length;
-
-                if (impressionTagLength >= 1 && feelingTagLength >= 1) {
-                    cardTag.push(mument.impressionTag[0], mument.feelingTag[0]);
-                } else if (impressionTagLength >= 1 && feelingTagLength < 1) {
-                    cardTag.push(...mument.impressionTag.slice(0, 2));
-                } else if (impressionTagLength < 1 && feelingTagLength >= 1) {
-                    cardTag.push(...mument.feelingTag.slice(0, 2));
-                }
-
-                const result: MumentResponseDto = {
-                    _id: mument._id,
-                    user: {
-                        _id: mument.user._id,
-                        image: mument.user.image,
-                        name: mument.user.name,
-                    },
-                    music: {
-                        _id: !music ? null : music._id,
-                        name: !music ? 'nonexistence' : music.name,
-                        artist: !music ? 'nonexistence' : music.artist,
-                        image: !music ? 'nonexistence' : music.image,
-                    },
-                    isFirst: mument.isFirst,
-                    impressionTag: mument.impressionTag,
-                    feelingTag: mument.feelingTag,
-                    cardTag: cardTag,
-                    content: mument.content,
-                    isPrivate: mument.isPrivate,
-                    likeCount: mument.likeCount,
-                    isLiked: !isLiked ? false : true,
-                    createdAt: dayjs(mument.createdAt).format('D MMM, YYYY'),
-                    year: Number(dayjs(mument.createdAt).format('YYYY')),
-                    month: Number(dayjs(mument.createdAt).format('M')),
-                };
-
-                return result;
-            }),
-        );
-
         return {
-            muments: data,
+            muments: result,
         };
     } catch (error) {
         console.log(error);

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -16,6 +16,7 @@ import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
 import mumentDB from '../modules/db/Mument';
 import userDB from '../modules/db/User';
 import { MyMumentInfoRDB } from '../interfaces/mument/MyMumentInfoRDB';
+import cardTag from '../modules/db/cardTagList';
 
 /**
  * 내가 작성한 뮤멘트 리스트
@@ -39,10 +40,13 @@ const getMyMumentList = async (userId: string, tagList: number[]): Promise<UserM
                 
                 // isLiked 좋아요 유무
                 const isLiked = await mumentDB.isLiked(item.mument_id.toString(), item.user_id.toString());
-                // 뮤멘트 태그 합치기
+                // 뮤멘트 태그 전체 합치기
                 cardTagList.push(item.tag_id);
-                // 태그 리스트 3개 이하로 자르기
-                cardTagList = cardTagList.slice(0, 3);
+
+                console.log('가공 전 태그리스트 ', cardTagList);
+                cardTagList = await cardTag.cardTag(cardTagList);
+                console.log('가공된 카드태그리스트 ', cardTagList);
+                console.log('');
 
                 result.push({
                     _id: item.mument_id,

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -47,12 +47,6 @@ const getMyMumentList = async (userId: string, tagList: number[]): Promise<UserM
                 // 뮤멘트 태그 전체 합치기
                 allCardTagList.push(item.tag_id);
 
-                console.log('가공 전 태그리스트 ', allCardTagList);
-                cardTagList = await cardTag.cardTag(allCardTagList);
-                console.log('가공된 카드태그리스트 ', cardTagList);
-                console.log('');
-                console.log('');
-
                 result.push({
                     _id: item.mument_id,
                     user: {


### PR DESCRIPTION
## **💿 DESCRIPTION**
보관함 내가 작성한 뮤멘트 리스트 - sql query 사용 로직으로 변경

- 내 뮤멘트이고, 삭제되지 않은 뮤멘트 리스트 최신순 나열
- 필터링 태그 1~3 존재시 뮤멘트 필터링 하도록
- 곡정보, 뮤멘트 정보, 좋아요 유무, 태그 리스트(cardTag 뮤멘트 카드에 띄우는 최대 2개 태그) 가공하기
- 날짜 & 년/월 가공하기


## **🎙 RELATED ISSUE**
#76  #10 

## **💃 REVIEW POINT**
보관함...들어오니까...갑자기 몽고디비가 그리워질 정도로 눈물이 주르륵 났습니다
좋아요한 뮤멘트 리스트는 더 걸릴 것 같네요 허헣...

- mument, mument_tag, music 테이블을 조인하는 쿼리를 User.ts 모듈에 분리해놨습니다.
- 조인된 결과는 하나의 mument_id에 대해 여러개의 mument_tag땜에 같은 mument id에 대해 여러 행이 나오기 때문에, 알고리즘은 -> 같은 mument id인 행들에 대해서만 mument tag를 리스트로 합치도록 구현했습니다!

- Mument.ts 모듈에 뮤멘트 태그를 가공하는 모듈이 있긴한데 보관함에선 뮤멘트가 매우 많기 때문에 해당 모듈을 쓰게되면 뮤멘트 마다 또 DB조회를 해야해서 최대한 JOIN한 후에 배열을 가공하도록 짜봤습니다!

- 한 뮤멘트의 전체 태그 리스트를 보내면 뮤멘트 카드에 띄울 태그를 처리하는 알고리즘(최대 2개, 인상태그&감정태그 1개씩)처리하는 모듈을 `src/modules/` 에 cardTagList.ts에 만들어서 사용했습니다
```
인상태그  [ 103, 101, 105 ]
감정태그  [ 203, 202, 200, 205 ]
가공된 카드태그리스트  [ 103, 203 ]
```

- 보관함  필터링 기능을 위해 mumentResponseDto에 optional로 allCardTag 키 추가해서 전체 태그 리스트 추가했습니다. 