### PR TITLE
[REFACTOR] request-header에서 token 받아서 user 객체 id 반환하는 미들웨어 생성 & 기존 채은 담당 api 모두 토큰 교체 완료

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,4 +29,10 @@ export default {
     password: process.env.DB_PASSWORD as string,
     database: process.env.DB_DATABASE as string,
     dbPort: parseInt(process.env.DB_PORT as string, 10) as number,
+
+    /**
+     * jwt Secret & Algorithm
+     */
+    jwtSecret: process.env.JWT_SECRET as string,
+    jwtAlgo: process.env.JWT_ALGO as string,
 };

--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -151,11 +151,15 @@ const deleteMument = async (req: Request, res: Response) => {
 };
 
 /**
- *  @ROUTE GET /mument/:userId/:musicId/is-first
+ *  @ROUTE GET /mument/:musicId/is-first
  *  @DESC 특정 음악에 대해 뮤멘트 기록하기 전 처음/다시 태그 판단
  */
 const getIsFirst = async (req: Request, res: Response) => {
     const { userId, musicId } = req.params;
+    const { musicId } = req.params;
+    
+    const userId = req.body.userId;
+    console.log(userId);
 
     try {
         const data = await MumentService.getIsFirst(userId, musicId);

--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -10,12 +10,13 @@ import { PostBaseResponseDto } from '../interfaces/common/PostBaseResponseDto';
 import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
 
 /**
- *  @ROUTE POST /mument/:userId/:musicId
- *  @DESC Create Mument
+ *  @ROUTE POST /mument/:musicId
+ *  @DESC Create Mument 뮤멘트 기록하기
  */
 const createMument = async (req: Request, res: Response) => {
     const mumentCreateDto: MumentCreateDto = req.body;
-    const { userId, musicId } = req.params;
+    const { musicId } = req.params;
+    const userId = req.body.userId;
 
     try {
         const data: PostBaseResponseDto | null = await MumentService.createMument(userId, musicId, mumentCreateDto);
@@ -46,7 +47,7 @@ const createMument = async (req: Request, res: Response) => {
 
 /**
  *  @ROUTE PUT /mument/:mumentId
- *  @DESC Update Mument
+ *  @DESC Update Mument 뮤멘트 수정하기
  */
 const updateMument = async (req: Request, res: Response) => {
     const error = validationResult(req);
@@ -85,11 +86,12 @@ const updateMument = async (req: Request, res: Response) => {
 };
 
 /**
- *  @ROUTE GET /:mumentId/:userId
- *  @DESC Get Mument
+ *  @ROUTE GET /:mumentId
+ *  @DESC Get Mument 뮤멘트 상세보기
  */
 const getMument = async (req: Request, res: Response) => {
-    const { mumentId, userId } = req.params;
+    const { mumentId} = req.params;
+    const userId = req.body.userId;
 
     try {
         const data = await MumentService.getMument(mumentId, userId);
@@ -155,11 +157,8 @@ const deleteMument = async (req: Request, res: Response) => {
  *  @DESC 특정 음악에 대해 뮤멘트 기록하기 전 처음/다시 태그 판단
  */
 const getIsFirst = async (req: Request, res: Response) => {
-    const { userId, musicId } = req.params;
-    const { musicId } = req.params;
-    
+    const { musicId } = req.params;    
     const userId = req.body.userId;
-    console.log(userId);
 
     try {
         const data = await MumentService.getIsFirst(userId, musicId);

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -6,7 +6,7 @@ import { UserService } from '../services';
 import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
 
 /**
- *  @ROUTE GET /my/:userId/list?tag1=&tag2=&tag3=
+ *  @ROUTE GET /my/list?tag1=&tag2=&tag3=
  *  @DESC 보관함에서 나의 뮤멘트 리스트를 조회합니다. 필터링이 필요한 경우 필터링합니다.
  */
 const getMyMumentList = async (req: Request, res: Response) => {
@@ -40,7 +40,7 @@ const getMyMumentList = async (req: Request, res: Response) => {
 };
 
 /**
- *  @ROUTE GET /like/:userId/list
+ *  @ROUTE GET /like/list?tag1=&tag2=&tag3=
  *  @DESC 보관함에서 좋아요한 뮤멘트 리스트를 조회합니다. 필터링이 필요한 경우 필터링합니다.
  */
 const getLikeMumentList = async (req: Request, res: Response) => {

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -11,10 +11,10 @@ import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
  */
 const getMyMumentList = async (req: Request, res: Response) => {
     const { tag1, tag2, tag3 } = req.query;
+    const userId = req.body.userId;
+
     let tagList = [Number(tag1), Number(tag2), Number(tag3)];
     tagList = tagList.filter(tag => isNaN(tag) === false);
-
-    const { userId } = req.params;
 
     try {
         const data = await UserService.getMyMumentList(userId, tagList);
@@ -45,10 +45,10 @@ const getMyMumentList = async (req: Request, res: Response) => {
  */
 const getLikeMumentList = async (req: Request, res: Response) => {
     const { tag1, tag2, tag3 } = req.query;
+    const userId = req.body.userId;
+
     let tagList = [Number(tag1), Number(tag2), Number(tag3)];
     tagList = tagList.filter(tag => isNaN(tag) === false);
-
-    const { userId } = req.params;
 
     try {
         const data = await UserService.getLikeMumentList(userId, tagList);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 const app = express();
 import routes from './routes';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -16,7 +16,7 @@ interface ErrorType {
     status: number;
 }
 
-app.use(function (err: ErrorType, req: Request, res: Response) {
+app.use(function (err: ErrorType, req: Request, res: Response, next: NextFunction) {
     res.locals.message = err.message;
     res.locals.error = req.app.get('env') === 'production' ? err : {};
 

--- a/src/interfaces/auth/JwtPayload.ts
+++ b/src/interfaces/auth/JwtPayload.ts
@@ -1,5 +1,5 @@
 export interface JwtPayloadInfo  {
-    "id": number,
-    "profileId"?: string,
-    "image"?: string
+    'id': number,
+    'profileId'?: string,
+    'image'?: string
 };

--- a/src/interfaces/user/UserInfoRDB.ts
+++ b/src/interfaces/user/UserInfoRDB.ts
@@ -4,12 +4,12 @@ export interface UserInfoRDB {
     provider: string;
     profile_id?: string;
     image?: string;
-    refresh_token?: string;
+    refresh_token?: string | null;
     is_deleted: number;
     created_at: Date;
     updated_at: Date;
-    authentication_code?: string;
-    gender?: string;
-    age_render?: string;
-    email?: string;
+    authentication_code?: string | null;
+    gender?: string | null;
+    age_render?: string | null;
+    email?: string | null;
 }

--- a/src/library/jwtHandler.ts
+++ b/src/library/jwtHandler.ts
@@ -5,9 +5,7 @@ import { decode } from 'punycode';
 import { JwtPayloadInfo } from '../interfaces/auth/JwtPayload';
 import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
 import constant from '../modules/serviceReturnConstant';
-
-// .env에서 시크릿키 가져오기
-const secretKey = process.env.JWT_SECRET;
+import config from '../config';
 
 const accessOption = {
     expiresIn: '30d',
@@ -27,7 +25,7 @@ const accessSign = (user: UserInfoRDB) => {
         image: user.image 
     };
 
-    const accessToken: string = jwt.sign(payload, secretKey, accessOption);
+    const accessToken: string = jwt.sign(payload, config.jwtSecret, accessOption);
 
     return accessToken;
 }
@@ -40,7 +38,7 @@ const refreshSign = (user: UserInfoRDB) => {
         image: user.image 
     };
 
-    const refreshToken: string = jwt.sign(payload, secretKey, refreshOption);
+    const refreshToken: string = jwt.sign(payload, config.jwtSecret, refreshOption);
 
     return refreshToken;
 }
@@ -48,7 +46,7 @@ const refreshSign = (user: UserInfoRDB) => {
 // 토큰 decode 함수
 const verify = (token: string) => {
     try {
-        const decoded: UserInfoRDB = jwt.verify(token, secretKey);
+        const decoded: UserInfoRDB = jwt.verify(token, config.jwtSecret);
         return decoded;
     } catch (err: any) {
         if (err.name == TokenExpiredError) {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,0 +1,82 @@
+import express, { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import config from '../config';
+import statusCode from '../modules/statusCode';
+import message from '../modules/responseMessage';
+import util from '../modules/util';
+import jwtHandler from '../library/jwtHandler';
+import constant from '../modules/serviceReturnConstant';
+import userDB from '../modules/db/User';
+import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
+import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
+
+/**
+ * request-header에서 받은 Bearer 토큰 처리 후 user 전달하는 미들웨어
+ */
+const auth = async (req: Request, res: Response, next: NextFunction) => {
+    // request-header에서 Bearer 토큰 받아오기
+    const token = req.headers["authorization"]?.split(' ').reverse()[0];
+
+    // 토큰 유무 검증
+    if (!token) return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.NULL_VALUE_TOKEN));
+
+
+    try {
+        // jwtHandler 토큰 decode 모듈사용
+        const decodedToken = jwtHandler.verify(token);
+
+        if (typeof decodedToken === 'number') {
+            // 상수값 대응
+            switch (decodedToken) {
+                case constant.TOKEN_EXPIRED: {
+                    return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_EXPIRED));
+                }
+                case constant.TOKEN_INVALID: {
+                    return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_INVALID));
+                }
+                case constant.WRONG_TOKEN: {
+                    return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.WRONG_TOKEN));
+                }
+                case constant.TOKEN_EXPIRED: {
+                    return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_EXPIRED));
+                }
+                case constant.TOKEN_UNKNOWN_ERROR: {
+                    return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_UNKNOWN_ERROR));
+                }
+            }
+
+        } else {
+             // 토큰 유저 정보 확인하기
+            const userId = decodedToken.id;
+
+            if (!userId) {
+                 return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_INVALID));
+            }
+
+            const user = await userDB.userInfo(userId.toString()); 
+            req.body.user = user.id;
+            next();
+        } 
+
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
+export default {
+    auth,
+}

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,19 +1,16 @@
 import express, { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
-import config from '../config';
 import statusCode from '../modules/statusCode';
 import message from '../modules/responseMessage';
 import util from '../modules/util';
 import jwtHandler from '../library/jwtHandler';
 import constant from '../modules/serviceReturnConstant';
 import userDB from '../modules/db/User';
-import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
 import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
 
 /**
  * request-header에서 받은 Bearer 토큰 처리 후 user 전달하는 미들웨어
  */
-const auth = async (req: Request, res: Response, next: NextFunction) => {
+export default async (req: Request, res: Response, next: NextFunction) => {
     // request-header에서 Bearer 토큰 받아오기
     const token = req.headers["authorization"]?.split(' ').reverse()[0];
 
@@ -49,12 +46,11 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
              // 토큰 유저 정보 확인하기
             const userId = decodedToken.id;
 
-            if (!userId) {
+            if (!userId || userId === undefined) {
                  return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_INVALID));
             }
 
-            const user = await userDB.userInfo(userId.toString()); 
-            req.body.user = user.id;
+            req.body.userId  = userId;
             next();
         } 
 
@@ -76,7 +72,3 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
         res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
     }
 };
-
-export default {
-    auth,
-}

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -50,6 +50,13 @@ const message = {
     APPLE_TOKEN_UNAUTHORIZED: '애플 API 개발자 토큰이 유효하지 않습니다',
     APPLE_SERVER_INTERNAL_ERROR: '애플 API 서버 자체 에러',
     NO_AUTHENTICATION_CODE: 'authentication code값이 없습니다',
+
+    //JWT
+    NULL_VALUE_TOKEN: 'request-header에 토큰이 없습니다',
+    TOKEN_EXPIRED: '토큰이 만료되었습니다',
+    TOKEN_INVALID: '유효하지 않은 토큰입니다',
+    WRONG_TOKEN: '잘못된 토큰입니다', //'jwt malformed' || 'jwt signature is required' || 'invalid signature'경우,
+    TOKEN_UNKNOWN_ERROR: '토큰 에러' // 그외의 토큰 에러
 };
 
 export default message;

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -6,7 +6,7 @@ import auth from '../middlewares/auth';
 const router: Router = Router();
 
 // 뮤멘트 기록하기
-router.post('/:userId/:musicId', MumentController.createMument);
+router.post('/:musicId', auth, MumentController.createMument);
 
 // 처음/다시 조회
 router.get('/:musicId/is-first', auth, MumentController.getIsFirst);
@@ -17,7 +17,7 @@ router.put('/:mumentId', [
 ], MumentController.updateMument);
 
 // 뮤멘트 상세보기
-router.get('/:mumentId/:userId', MumentController.getMument);
+router.get('/:mumentId', auth, MumentController.getMument);
 
 //뮤멘트 삭제하기
 router.delete('/:mumentId', MumentController.deleteMument);

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -1,17 +1,25 @@
 import { Router } from 'express';
 import { MumentController } from '../controllers';
 import { body, param, query } from 'express-validator';
+import auth from '../middlewares/auth';
 
 const router: Router = Router();
 
+// 뮤멘트 기록하기
 router.post('/:userId/:musicId', MumentController.createMument);
 
+// 처음/다시 조회
+router.get('/:musicId/is-first', auth, MumentController.getIsFirst);
+
+// 뮤멘트 수정하기
 router.put('/:mumentId', [
     body('isFirst').notEmpty(),
 ], MumentController.updateMument);
-router.get('/:mumentId/:userId', MumentController.getMument);
-router.get('/:userId/:musicId/is-first', MumentController.getIsFirst);
 
+// 뮤멘트 상세보기
+router.get('/:mumentId/:userId', MumentController.getMument);
+
+//뮤멘트 삭제하기
 router.delete('/:mumentId', MumentController.deleteMument);
 
 // 히스토리 조회

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -1,10 +1,11 @@
 import { Router } from 'express';
 import { body } from 'express-validator';
 import { UserController } from '../controllers';
+import auth from '../middlewares/auth';
 
 const router: Router = Router();
 
-router.get('/my/:userId/list', UserController.getMyMumentList);
-router.get('/like/:userId/list', UserController.getLikeMumentList);
+router.get('/my/list', auth, UserController.getMyMumentList);
+router.get('/like/list', auth, UserController.getLikeMumentList);
 
 export default router;

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -138,7 +138,7 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
         const mument = isExistMumentInfo.mument as MumentInfoRDB; // 뮤멘트 데이터 가져오기
 
         //  비밀글인데, 본인의 뮤멘트가 아닐 경우 -> 조회하지 못하도록
-        if (mument.is_private === 1 && mument.user_id.toString() !== userId) return constant.PRIVATE_MUMENT;
+        if (mument.is_private === 1 && mument.user_id.toString() != userId) return constant.PRIVATE_MUMENT;
 
     
         // 사용자가 이 뮤멘트에 좋아요 눌렀으면 1, 아니면 0

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,12 +1,6 @@
 import dayjs from 'dayjs';
 import { UserMumentListResponseDto } from '../interfaces/user/UserMumentListResponseDto';
 import { MumentResponseDto } from '../interfaces/mument/MumentResponseDto';
-import { LikeInfo } from '../interfaces/like/LikeInfo';
-import { MumentInfo } from '../interfaces/mument/MumentInfo';
-import { UserInfo } from '../interfaces/user/UserInfo';
-import pools from '../modules/pool';
-import { MumentInfoRDB } from '../interfaces/mument/MumentInfoRDB';
-import { UserInfoRDB } from '../interfaces/user/UserInfoRDB';
 import mumentDB from '../modules/db/Mument';
 import userDB from '../modules/db/User';
 import { MyMumentInfoRDB } from '../interfaces/mument/MyMumentInfoRDB';


### PR DESCRIPTION
## **💿 DESCRIPTION**
- request-header에서 token 받아서 user 객체 id 반환하는 미들웨어 생성
- 기존 채은 담당 api 모두 토큰 교체 완료!!

## **🎙 RELATED ISSUE**
#87 

## **💃 REVIEW POINT**
- request-header에서 받은 Bearer 토큰 처리 후 user의 id를 전달하는 미들웨어 auth 생성했습니다 -> src/middlewares/auth.ts
해당 파일을 라우터에서 url과 컨트롤러 사이에 넣어준 후 컨트롤러에서 해당 값을 req.body.userId로 받으면 됩니다!!

- 기존 담당 api 모두 토큰 처리 완료 = 이제 기존 api 제 담당은 모두 끝났습니다! 코드리뷰받으면 오늘(화요일)에 서버에 올리고 클라분들께 알릴 예정입니다 
- [x]  보관함 - 나의 뮤멘트
- [x]  보관함 - 좋아요한 뮤멘트
- [x]  처음/다시 들어요 선택
- [x]  뮤멘트 기록하기
- [x]  뮤멘트 상세보기