### PR TITLE
[FEAT] 보관함 좋아요 뮤멘트 리스트에서 차단한 유저의 뮤멘트 안보이게 로직 추가 #91

### DIFF
--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -1,6 +1,8 @@
 import { UserInfoRDB } from '../../interfaces/user/UserInfoRDB';
 import pools from '../pool';
 import { MyMumentInfoRDB } from '../../interfaces/mument/MyMumentInfoRDB';
+import { NumberBaseResponseDto } from '../../interfaces/common/NumberBaseResponseDto';
+import pool from '../pool';
 
 /**
  * user 관련 재사용 쿼리 - 트랜잭션 쓸 때 사용가능
@@ -62,9 +64,22 @@ const myLikeMumentList = async (userId: string) => {
 };
 
 
+// userId가 차단한 유저 배열 반환
+const blockedUserList = async (userId: string) => {
+    const selectBlockQuery = `
+        SELECT blocked_user_id as exist 
+            FROM block WHERE user_id=?;`;
+
+    const blockedUserList: NumberBaseResponseDto[] = await pools.queryValue(selectBlockQuery, [userId]);
+    
+    return blockedUserList;
+};
+
+
 export default {
     userInfo,
     myMumentList,
-    myLikeMumentList
+    myLikeMumentList,
+    blockedUserList
 }
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -115,9 +115,19 @@ const getLikeMumentList = async (userId: string, tagList: number[]): Promise<Use
         // 카드뷰에 띄울 가공된 태그 리스트를 넣을 배열
         let cardTagList: number[] = [];
 
+        // 사용자가 차단한 유저 배열
+        const blockedUserList = await userDB.blockedUserList(userId);
 
-        const likeMumentListFunc = async (item: MyMumentInfoRDB, idx: number) => {
-            if (idx === likeMumentList.length - 1 || (idx < likeMumentList.length - 1 && likeMumentList[idx + 1].mument_id !== item.mument_id)) {
+        const likeMumentListFunc = async (acc: any, item: MyMumentInfoRDB, idx: number) => {
+            
+            const isBlocked = blockedUserList.find(({ exist }) => exist == item.user_id);
+            if (isBlocked !== undefined) {
+                //차단된 유저의 뮤멘트라면 reduce가 다음 코드 실행안함
+                return acc;
+            }
+
+            if (idx === likeMumentList.length - 1 
+                || (idx < likeMumentList.length - 1 && likeMumentList[idx + 1].mument_id !== item.mument_id)) {
                 
                 // 뮤멘트 태그 전체 합치기
                 if (item.tag_id) allCardTagList.push(item.tag_id);
@@ -159,8 +169,8 @@ const getLikeMumentList = async (userId: string, tagList: number[]): Promise<Use
             }
         };
 
-        await likeMumentList.reduce(async (pre, curr, index) => {
-                return pre.then(() => likeMumentListFunc(curr, index));
+        await likeMumentList.reduce(async (acc, curr, index) => {
+                return acc.then(() => likeMumentListFunc(acc, curr, index));
         }, Promise.resolve());
 
 


### PR DESCRIPTION
## **💿 DESCRIPTION**
보관함 좋아요 뮤멘트 리스트에서 차단한 유저의 뮤멘트 안보이게 로직 추가

## **🎙 RELATED ISSUE**

## **💃 REVIEW POINT**
- 좋아요한 뮤멘트 리스트에 대해 → 차단 유저 id가 담긴 리스트를 가져와서 차단된 유저일 경우 다음 코드를 실행하지 않도록 find함수와 reduce특성을 이용했습니다