### PR TITLE
[FEAT] 유저 차단하기, 차단 유저 리스트, 유저 차단 해제 API 구현

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -4,6 +4,7 @@ import message from '../modules/responseMessage';
 import util from '../modules/util';
 import { UserService } from '../services';
 import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
+import constant from '../modules/serviceReturnConstant';
 
 /**
  *  @ROUTE GET /my/list?tag1=&tag2=&tag3=
@@ -73,7 +74,47 @@ const getLikeMumentList = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ *  @ROUTE POST /block/:mumentId
+ *  @DESC 뮤멘트 작성 유저를 차단합니다.
+ */
+const blockUser = async (req: Request, res: Response) => {
+    const { mumentId } = req.params;
+    const userId = req.body.userId;
+
+    try {
+        const data = await UserService.blockUser(userId, mumentId);
+        
+        if (data === constant.NO_MUMENT) {
+            return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NO_MUMENT_ID));
+        } else if (data === constant.ALREADY_BLOCK) {
+            return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.ALREADY_BLOCK_USER));
+        } else if (data === constant.SELF_BLOCK) {
+            return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.SELF_BLOCK));
+        }
+
+        return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, message.BLOCK_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 export default {
     getMyMumentList,
     getLikeMumentList,
+    blockUser,
 };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -80,7 +80,7 @@ const getLikeMumentList = async (req: Request, res: Response) => {
  */
 const blockUser = async (req: Request, res: Response) => {
     const { mumentId } = req.params;
-    const userId = req.body.userId;
+    const userId: number = req.body.userId;
 
     try {
         const data = await UserService.blockUser(userId, mumentId);
@@ -113,8 +113,39 @@ const blockUser = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ *  @ROUTE GET /block
+ *  @DESC 차단한 유저 리스트를 조회합니다.
+ */
+const getBlockedUserList =  async (req: Request, res: Response) => {
+    const userId: number = req.body.userId;
+
+    try {
+        const data = await UserService.getBlockedUserList(userId);
+
+        return res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_BLOCK_LIST, data));
+    }  catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 export default {
     getMyMumentList,
     getLikeMumentList,
     blockUser,
+    getBlockedUserList,
 };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -114,17 +114,18 @@ const blockUser = async (req: Request, res: Response) => {
 };
 
 /**
- *  @ROUTE GET /block
- *  @DESC 차단한 유저 리스트를 조회합니다.
+ *  @ROUTE DELETE /block/:blockedUserId
+ *  @DESC 차단한 유저를 차단 해제합니다.
  */
-const getBlockedUserList =  async (req: Request, res: Response) => {
+const deleteBlockUser = async (req: Request, res: Response) => {
+    const { blockedUserId } = req.params;
     const userId: number = req.body.userId;
-
+    
     try {
-        const data = await UserService.getBlockedUserList(userId);
+        const data = await UserService.deleteBlockUser(userId, blockedUserId);
 
-        return res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_BLOCK_LIST, data));
-    }  catch (error) {
+        return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT, message.DELETE_BLOCKED_USER_SUCCESS));
+    } catch (error) {
         console.log(error);
 
         const slackMessage: SlackMessageFormat = {
@@ -143,9 +144,41 @@ const getBlockedUserList =  async (req: Request, res: Response) => {
     }
 };
 
+/**
+ *  @ROUTE GET /block
+ *  @DESC 차단한 유저 리스트를 조회합니다.
+ */
+const getBlockedUserList =  async (req: Request, res: Response) => {
+    const userId: number = req.body.userId;
+
+    try {
+        const data = await UserService.getBlockedUserList(userId);
+
+        return res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_BLOCK_LIST, data));
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
+
 export default {
     getMyMumentList,
     getLikeMumentList,
     blockUser,
+    deleteBlockUser,
     getBlockedUserList,
 };

--- a/src/interfaces/user/UserResponseDto.ts
+++ b/src/interfaces/user/UserResponseDto.ts
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 
 export interface UserResponseDto {
-    id: mongoose.Types.ObjectId;
+    id: mongoose.Types.ObjectId | string;
     profileId: string;
-    name: string;
+    name?: string; // RDB에서 name 필드 제거했기 때문에 옵셔널로 수정함
     image?: string;
 }

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -18,6 +18,7 @@ const message = {
     BLOCK_SUCCESS: '유저 차단하기 성공',
     ALREADY_BLOCK_USER: '이미 차단한 유저입니다',
     SELF_BLOCK: '자기자신은 차단할 수 없습니다',
+    READ_BLOCK_LIST: '차단 유저 조회 성공',
 
     // mument
     NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -19,6 +19,7 @@ const message = {
     ALREADY_BLOCK_USER: '이미 차단한 유저입니다',
     SELF_BLOCK: '자기자신은 차단할 수 없습니다',
     READ_BLOCK_LIST: '차단 유저 조회 성공',
+    DELETE_BLOCKED_USER_SUCCESS: '유저 차단 해제 성공',
 
     // mument
     NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -15,6 +15,9 @@ const message = {
     SIGNUP_SUCCESS: '회원가입 성공',
     READ_MY_MUMENT_LIST_SUCCESS: '나의 뮤멘트 리스트 조회 성공',
     READ_LIKE_MUMENT_LIST_SUCCESS: '좋아요한 뮤멘트 리스트 조회 성공',
+    BLOCK_SUCCESS: '유저 차단하기 성공',
+    ALREADY_BLOCK_USER: '이미 차단한 유저입니다',
+    SELF_BLOCK: '자기자신은 차단할 수 없습니다',
 
     // mument
     NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',

--- a/src/modules/serviceReturnConstant.ts
+++ b/src/modules/serviceReturnConstant.ts
@@ -28,6 +28,10 @@ const constant = {
     WRONG_TOKEN: -102, // 올바르지 않은 토큰일 때
     TOKEN_NOT_BEFORE: -103, // 아직 갱신할 수 없는 토큰일 때
     TOKEN_UNKNOWN_ERROR: -199, // 알 수 없는 토큰 에러
+
+    // 유저 차단
+    ALREADY_BLOCK: -200, // 이미 차단한 유저를 다시 차단하려 할 떄
+    SELF_BLOCK: -201,
 };
 
 export default constant;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -8,6 +8,7 @@ const router: Router = Router();
 router.get('/my/list', auth, UserController.getMyMumentList);
 router.get('/like/list', auth, UserController.getLikeMumentList);
 router.post('/block/:mumentId', auth, UserController.blockUser);
+router.delete('/block/:blockedUserId', auth, UserController.deleteBlockUser);
 router.get('/block', auth, auth, UserController.getBlockedUserList);
 
 export default router;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -8,5 +8,6 @@ const router: Router = Router();
 router.get('/my/list', auth, UserController.getMyMumentList);
 router.get('/like/list', auth, UserController.getLikeMumentList);
 router.post('/block/:mumentId', auth, UserController.blockUser);
+router.get('/block', auth, auth, UserController.getBlockedUserList);
 
 export default router;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -7,5 +7,6 @@ const router: Router = Router();
 
 router.get('/my/list', auth, UserController.getMyMumentList);
 router.get('/like/list', auth, UserController.getLikeMumentList);
+router.post('/block/:mumentId', auth, UserController.blockUser);
 
 export default router;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -8,6 +8,9 @@ import cardTagListProvider from '../modules/cardTagList';
 import poolPromise from '../loaders/db';
 import constant from '../modules/serviceReturnConstant';
 import { NumberBaseResponseDto } from '../interfaces/common/NumberBaseResponseDto';
+import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+import pools from '../modules/pool';
+
 
 /**
  * 내가 작성한 뮤멘트 리스트
@@ -255,9 +258,30 @@ const blockUser = async (userId: number, mumentId: string): Promise<number | Num
     }
 };
 
+const getBlockedUserList = async (userId: number): Promise<UserResponseDto[] | number> => {
+    try {
+        const selectBlockQuery = `
+            SELECT blocked_user_id as id, user.profile_id, user.image FROM block
+            JOIN user ON block.blocked_user_id=user.id
+            WHERE block.user_id=? AND user.is_deleted=0;
+        `;
+        const blockedUserList: UserResponseDto[] = await pools.queryValue(selectBlockQuery, [
+            userId
+        ]);
+
+        const data: UserResponseDto[] = blockedUserList;
+
+        return data;
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
+
 
 export default {
     getMyMumentList,
     getLikeMumentList,
     blockUser,
+    getBlockedUserList,
 };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -258,6 +258,21 @@ const blockUser = async (userId: number, mumentId: string): Promise<number | Num
     }
 };
 
+const deleteBlockUser = async (userId: number, blockedUserId: string): Promise<void> => {
+    try {
+        const deleteBlockQuery = `DELETE FROM block WHERE user_id=? AND blocked_user_id=?`;
+
+        await pools.queryValue(deleteBlockQuery, [
+            userId,
+            blockedUserId
+        ]);
+
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
+
 const getBlockedUserList = async (userId: number): Promise<UserResponseDto[] | number> => {
     try {
         const selectBlockQuery = `
@@ -283,5 +298,6 @@ export default {
     getMyMumentList,
     getLikeMumentList,
     blockUser,
+    deleteBlockUser,
     getBlockedUserList,
 };


### PR DESCRIPTION
## **💿 DESCRIPTION**
 - 유저 차단하기 API
 - 차단 유저 리스트 API
 -유저 차단 해제 API

위 3개 API 모두 [토큰 처리, 라우터, 컨트롤러, 서비스 로직] 작성 완료했습니다.

## **🎙 RELATED ISSUE**
#94 

## **💃 REVIEW POINT**
- 유저 차단하기
1. 자기 자신을 차단하려하면 400
2. 이미 차단한 유저를 또 차단하려하면 400
3. 존재하지않는 뮤멘트의 작성자를 차단하려하면 404
4. block 테이블에 차단 row 삽입하기

- 차단 유저 리스트
1. 탈퇴한 유저는 차단 유저 리스트에 뜨지 않음
2. 차단한 유저가 없으면 빈 배열 [] 반환함

- 유저 차단 해제
1. 차단 유저 리스트에서 차단하는 것이기 때문에, 차단하지 않은 유저일리 없다고 판단하여 따로 에러 처리 하지않음
2. block 테이블에서 차단 row 삭제하기