### PR TITLE
[FEAT] 신고 제재 기간인 유저를 controller로 넘어가지 않게 하는 미들웨어 작성 & 뮤멘트 기록하기, 수정하기에 적용

### DIFF
--- a/src/interfaces/user/ReportRestrictionInfoRDB.ts
+++ b/src/interfaces/user/ReportRestrictionInfoRDB.ts
@@ -1,0 +1,8 @@
+// RDB에서 SELECT한 reportRestriction 레코드 타입 정의
+export interface ReportRestrictionInfoRDB {
+    id: number;
+    user_id: number;
+    report_id: number;
+    restrict_start_date: Date;
+    restrict_end_date: Date;
+}

--- a/src/middlewares/reportRestriction.ts
+++ b/src/middlewares/reportRestriction.ts
@@ -1,0 +1,53 @@
+import express, { Request, Response, NextFunction } from 'express';
+import statusCode from '../modules/statusCode';
+import message from '../modules/responseMessage';
+import util from '../modules/util';
+import constant from '../modules/serviceReturnConstant';
+import userDB from '../modules/db/User';
+import sendMessage, { SlackMessageFormat } from '../library/slackWebHook';
+import poolPromise from '../loaders/db';
+import dayjs from 'dayjs';
+import { ReportRestrictionInfoRDB } from '../interfaces/user/ReportRestrictionInfoRDB';
+
+/**
+ * 신고로 인해 이용 제재중인 유저 처리 미들웨어
+ */
+export default async (req: Request, res: Response, next: NextFunction) => {
+    // request-header에서 Bearer 토큰 받아오기
+    const userId = req.body.userId;
+    const pool: any = await poolPromise;
+    const connection = await pool.getConnection();
+
+    try {
+        const selectReportRestrictionQuery = 'SELECT * FROM report_restriction WHERE user_id=?';
+        const restriction: ReportRestrictionInfoRDB[] = await connection.query(selectReportRestrictionQuery, [userId]);
+
+        if (restriction.length === 0 ) next();
+
+        /**
+         * 현재 날짜 < 제재 마감일 이면 컨트롤러로 가는 것 제재함
+         *  */ 
+        const curr = new Date();
+        const utc = curr.getTime() + (curr.getTimezoneOffset() * 60 * 1000);
+        const KR_TIME_DIFF = 9 * 60 * 60 * 1000;
+
+
+        // 한국 시간으로 현재 날짜 생성
+        const kr_curr_date = new Date(utc + (KR_TIME_DIFF));
+
+
+        if (dayjs(kr_curr_date).isBefore(restriction[0].restrict_end_date)) {
+            return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.REPORT_RESTRICTION_USER));
+        }
+        
+        next();
+
+        await connection.commit(); // query1, query2 모두 성공시 커밋(데이터 적용)
+    } catch (error) {
+        console.log(error);
+        await connection.rollback(); // query1, query2 중 하나라도 에러시 롤백 (데이터 적용 원상복귀)
+        throw error;
+    } finally {
+        connection.release(); // pool connection 회수
+    }
+};

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -61,7 +61,10 @@ const message = {
     TOKEN_EXPIRED: '토큰이 만료되었습니다',
     TOKEN_INVALID: '유효하지 않은 토큰입니다',
     WRONG_TOKEN: '잘못된 토큰입니다', //'jwt malformed' || 'jwt signature is required' || 'invalid signature'경우,
-    TOKEN_UNKNOWN_ERROR: '토큰 에러' // 그외의 토큰 에러
+    TOKEN_UNKNOWN_ERROR: '토큰 에러', // 그외의 토큰 에러
+
+    //신고 제재
+    REPORT_RESTRICTION_USER: '신고 제재를 받고있는 유저입니다',
 };
 
 export default message;

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -2,11 +2,12 @@ import { Router } from 'express';
 import { MumentController } from '../controllers';
 import { body, header, param, query } from 'express-validator';
 import auth from '../middlewares/auth';
+import reportRestriction from '../middlewares/reportRestriction';
 
 const router: Router = Router();
 
 // 뮤멘트 기록하기
-router.post('/:musicId', auth, MumentController.createMument);
+router.post('/:musicId', auth, reportRestriction, MumentController.createMument);
 
 // 처음/다시 조회
 router.get('/:musicId/is-first', auth, MumentController.getIsFirst);
@@ -14,7 +15,7 @@ router.get('/:musicId/is-first', auth, MumentController.getIsFirst);
 // 뮤멘트 수정하기
 router.put('/:mumentId', [
     body('isFirst').notEmpty(),
-], MumentController.updateMument);
+], auth, reportRestriction, MumentController.updateMument);
 
 // 뮤멘트 상세보기
 router.get('/:mumentId', auth, MumentController.getMument);


### PR DESCRIPTION
## **💿 DESCRIPTION**
- 신고 제재 기간인 유저를 controller로 넘어가지 않게 하는 미들웨어 작성함
- 뮤멘트 기록하기, 수정하기에 신고 제재 미들웨어 적용

## **🎙 RELATED ISSUE**
#96

## **💃 REVIEW POINT**
- 현재 report 테이블은 신고하기에서 신고 접수용으로 쓰이기 때문에, 기획에서 신고 제재를 확정한 유저들을 넣는 테이블을 `report_restriction`이라는 이름으로 만들어서 이 코드에 사용했습니다.
```
create table mument.report_restriciton
(
    id                  int auto_increment,
    user_id             int  not null comment '신고 제재 유저 id - 유저id는 unique',
    report_id           int  null comment '신고 보고 id-> 최신 보고id',
    restrict_start_date DATE not null comment '제재 시작일',
    restrict_end_date   DATE  not null comment '제재 마감일',
    constraint id
        primary key (id),
    constraint report_id
        foreign key (report_id) references mument.report (id),
    constraint user_id
        foreign key (user_id) references mument.user (id)
)
    comment '기획에서 신고사항 검토후 제재를 주기로 결정한 유저를 넣는 테이블';
```

- 신고 제재기한 중에 있는 유저의 행위를 제재하는 `reportRestriction.ts` 미들웨어를 작성했습니다
- 제재 기한 중인 유저에 대해 아래와 같은 response를 보냅니다. 해당 부분API ver2 페이지 상단에 기입했습니다
```
{
    "status": 400,
    "success": false,
    "message": "신고 제재를 받고있는 유저입니다"
}
```
- 현재 날짜 < 제재 마감일 이면 controller로 가는 것을 제재 하는 코드입니다 → 한국 시간으로 계산하게 코드 작성해놨으나, 서버 배포 후에도 정확히 맞는지 확인해야함