### PR TITLE
[FEAT] 뮤멘트 신고하기 API 구현

### DIFF
--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -52,7 +52,7 @@ const createMument = async (req: Request, res: Response) => {
 const updateMument = async (req: Request, res: Response) => {
     const error = validationResult(req);
     if (!error.isEmpty()) {
-        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST));
+        return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST));
     }
 
     const { mumentId } = req.params;
@@ -61,7 +61,7 @@ const updateMument = async (req: Request, res: Response) => {
     try {
         const data = await MumentService.updateMument(mumentId, mumentUpdateDto);
 
-        if (data===constant.NO_MUMENT) {
+        if (data === constant.NO_MUMENT) {
             return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NO_MUMENT_ID));
         } 
         
@@ -194,7 +194,7 @@ const getMumentHistory = async (req: Request, res: Response) => {
 
     const error = validationResult(req);
     if (!error.isEmpty()) {
-        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
+        return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
     }
 
     let orderBy: string = 'DESC';
@@ -248,7 +248,7 @@ const createLike = async (req: Request, res: Response) => {
 
     const error = validationResult(req);
     if (!error.isEmpty()) {
-        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
+        return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
     }
 
     try {
@@ -296,7 +296,7 @@ const deleteLike = async (req: Request, res: Response) => {
 
     const error = validationResult(req);
     if (!error.isEmpty()) {
-        res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
+        return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.WRONG_PARAMS));
     }
 
     try {
@@ -528,6 +528,47 @@ const getNoticeList = async (req: Request, res: Response) => {
     }
 };
 
+/**
+ * @ROUTE POST /mument/report/:mumentId
+ * @DESC 뮤멘트 신고하기
+ */
+const createReport = async (req: Request, res: Response) => {
+    const error = validationResult(req);
+    if (!error.isEmpty()) {
+        return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.BODY_REQUIRED));
+    }
+
+    const { mumentId } = req.params;
+    const { reportCategory, etcContent } = req.body;
+    const userId = req.body.userId
+
+    try {
+        const data = await MumentService.createReport(mumentId, reportCategory, etcContent, userId);
+
+        if (data === constant.NO_MUMENT) {
+            return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NO_MUMENT_ID));
+        } 
+        
+        return res.status(statusCode.CREATED).send(util.success(statusCode.CREATED, message.CREATE_REPORT_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 
 export default {
     createMument,
@@ -544,4 +585,5 @@ export default {
     getAgainMument,
     getNoticeDetail,
     getNoticeList,
+    createReport,
 };

--- a/src/controllers/MumentController.ts
+++ b/src/controllers/MumentController.ts
@@ -464,7 +464,10 @@ const getAgainMument = async (req: Request, res: Response) => {
     }
 };
 
-
+/**
+ * @ROUTE GET /mument/notice/:noticeId
+ * @DESC 공지사항 상세보기 조회
+ */
 const getNoticeDetail = async (req: Request, res: Response) => {
     const { noticeId } = req.params;
 
@@ -496,7 +499,10 @@ const getNoticeDetail = async (req: Request, res: Response) => {
     }
 };
 
-
+/**
+ * @ROUTE GET /mument/notice/
+ * @DESC 공지사항 리스트 조회
+ */
 const getNoticeList = async (req: Request, res: Response) => {
     try {
         const data = await MumentService.getNoticeList();

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -67,6 +67,7 @@ const message = {
 
     //신고 제재
     REPORT_RESTRICTION_USER: '신고 제재를 받고있는 유저입니다',
+    CREATE_REPORT_SUCCESS: '뮤멘트 신고하기 성공',
 };
 
 export default message;

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -49,7 +49,7 @@ router.get('/banner', MumentController.getBanner);
 // 다시 들은 뮤멘트
 router.get('/again', MumentController.getAgainMument);
 
-// 공시자항 상세보기
+// 공시자항 리스트
 router.get('/notice', MumentController.getNoticeList);
 
 // 공시자항 상세보기
@@ -58,7 +58,10 @@ router.get('/notice/:noticeId', MumentController.getNoticeDetail);
 // 뮤멘트 상세보기
 router.get('/:mumentId', auth, MumentController.getMument);
 
-//뮤멘트 삭제하기
+// 뮤멘트 삭제하기
 router.delete('/:mumentId', MumentController.deleteMument);
+
+// 신고하기
+router.post('/report/:mumentId', auth, MumentController.createReport);
 
 export default router;

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -62,6 +62,9 @@ router.get('/:mumentId', auth, MumentController.getMument);
 router.delete('/:mumentId', MumentController.deleteMument);
 
 // 신고하기
-router.post('/report/:mumentId', auth, MumentController.createReport);
+router.post('/report/:mumentId', [
+    body('reportCategory').notEmpty(),
+    body('etcContent').notEmpty(),
+], auth, MumentController.createReport);
 
 export default router;


### PR DESCRIPTION
## **💿 DESCRIPTION**
뮤멘트 신고하기 API 라우터, 컨트롤러, 서비스 로직 구현

## **🎙 RELATED ISSUE**
# 101

## **💃 REVIEW POINT**
- 신고 테이블 report에 신고하는 뮤멘트의 id를 넣을 수 있는 mument_id 컬럼 추가했습니다!

- 신고 사유는 다중 선택 가능이어서 배열로 받아서 reduce를 통해 모든 신고 사유를 POST합니다.

- request-header에 token이 없으면 401, request-body에 신고사유랑 내용을 보내지 않으면 400