### PR TITLE
FEAT: 소식창 시리즈 API - 소식창 리스트 조회 & 소식창 알림 제거 & 홈 새로운 알림 유무 조회 & 새로운 알림 읽음 처리 API 구현

### DIFF
--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 import statusCode from '../modules/statusCode';
 import message from '../modules/responseMessage';
 import util from '../modules/util';
@@ -174,6 +174,36 @@ const getBlockedUserList =  async (req: Request, res: Response) => {
     }
 };
 
+/**
+ *  @ROUTE GET /news
+ *  @DESC 소식창 리스트를 조회합니다.
+ */
+const getNewsList = async (req: Request, res: Response) => {
+    const userId: number = req.body.userId;
+
+    try {
+        const data = await UserService.getNewsList(userId);
+
+        return res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_NEWS_LIST_SUCCESS, data));
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
 
 export default {
     getMyMumentList,
@@ -181,4 +211,5 @@ export default {
     blockUser,
     deleteBlockUser,
     getBlockedUserList,
+    getNewsList,
 };

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -176,6 +176,38 @@ const getBlockedUserList =  async (req: Request, res: Response) => {
 };
 
 
+/**
+ *  @ROUTE GET /news/exist
+ *  @DESC 소식창에 안읽은 알림이 있는지 조회합니다. 
+ */
+const getUnreadNewsisExist = async (req: Request, res: Response) => {
+    const userId: number = req.body.userId;
+
+    try {
+        const data = await UserService.getUnreadNewsisExist(Number(userId));
+
+        return res.status(statusCode.OK).send(util.success(statusCode.OK, message.READ_UNREAD_NEWS_IS_EXIST_SUCCESS, data));
+
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+
+};
+
 
 /**
  *  @ROUTE PATCH /news/read
@@ -211,7 +243,6 @@ const updateUnreadNews = async (req: Request, res: Response) => {
         res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
     }
 };
-
 
 
 
@@ -288,6 +319,7 @@ export default {
     blockUser,
     deleteBlockUser,
     getBlockedUserList,
+    getUnreadNewsisExist,
     updateUnreadNews,
     deleteNews,
     getNewsList,

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -176,6 +176,45 @@ const getBlockedUserList =  async (req: Request, res: Response) => {
 };
 
 
+
+/**
+ *  @ROUTE PATCH /news/read
+ *  @DESC 안읽은 새로운 알림들을 읽음 처리합니다.
+ */
+const updateUnreadNews = async (req: Request, res: Response) => {
+    const userId: number = req.body.userId;
+    const { unreadNews } = req.body;
+
+    try {
+        const data = await UserService.updateUnreadNews(Number(userId), unreadNews);
+
+        if (data === constant.UPDATE_FAIL) {
+            return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST));
+        }
+
+        return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT, message.READ_UNREAD_NEWS_SUCCESS));
+    } catch (error) {
+        console.log(error);
+
+        const slackMessage: SlackMessageFormat = {
+            title: 'MUMENT ec2 서버 오류',
+            text: '서버 내부 오류입니다',
+            fields: [
+                {
+                    title: 'Error Stack:',
+                    value: `\`\`\`${error}\`\`\``,
+                },
+            ],
+        };
+        sendMessage(slackMessage);
+
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, message.INTERNAL_SERVER_ERROR));
+    }
+};
+
+
+
+
 /**
  *  @ROUTE PATCH /news/:newsId
  *  @DESC 소식창 알림을 제거합니다.
@@ -249,6 +288,7 @@ export default {
     blockUser,
     deleteBlockUser,
     getBlockedUserList,
+    updateUnreadNews,
     deleteNews,
     getNewsList,
 };

--- a/src/interfaces/user/NewsInfoRDB.ts
+++ b/src/interfaces/user/NewsInfoRDB.ts
@@ -1,0 +1,13 @@
+// RDB에서 SELECT한 news(공지사항) 레코드 타입 정의
+export interface NewsInfoRDB{
+    id: number;
+    type: string;
+    user_id: number;
+    is_deleted: boolean;
+    is_read: boolean;
+    created_at: Date | string;
+    link_id: number; // 공지사항 알림: 공지사항 id / 좋아요 알림: 좋아요 눌린 뮤멘트 id
+    notice_title: string | null;
+    like_profile_id: string | null;
+    like_music_title: string | null;
+}

--- a/src/interfaces/user/NewsResponseDto.ts
+++ b/src/interfaces/user/NewsResponseDto.ts
@@ -1,0 +1,13 @@
+// 공지사항 DTO
+export interface NewsResponseDto{
+    id: number;
+    type: string;
+    userId: number;
+    isDeleted: boolean;
+    isRead: boolean;
+    createdAt: Date | string;
+    linkId: number;
+    noticeTitle: string | null;
+    likeProfileId: string | null;
+    likeMusicTitle: string | null;
+}

--- a/src/modules/db/Auth.ts
+++ b/src/modules/db/Auth.ts
@@ -1,2 +1,0 @@
-import pools from '../pool';
-import { UserInfoRDB } from '../../interfaces/user/UserInfoRDB';

--- a/src/modules/db/Mument.ts
+++ b/src/modules/db/Mument.ts
@@ -104,18 +104,6 @@ const mumentTagListGet = async (mumentId: string) => {
     };
 };
 
-// 뮤멘트 id에 해당하는 태그 리스트로 반환하기
-const mumentTagList = async (mumentId: string) => {
-    const query = `SELECT * FROM mument_tag WHERE mument_id=${mumentId};`;
-
-    let tagList: number[] = [];
-    for (let tag in tagList) {
-        
-    }
-
-    return tagList;
-};
-
 
 export default {
     mumentTagCreate,
@@ -125,5 +113,4 @@ export default {
     likeCount,
     mumentHistoryCount,
     mumentTagListGet,
-    mumentTagList
 }

--- a/src/modules/db/Music.ts
+++ b/src/modules/db/Music.ts
@@ -20,7 +20,7 @@ const SearchAndCreateMusic = async (mumentCreateDto: MumentCreateDto, connection
             mumentCreateDto.musicImage, mumentCreateDto.musicName
         ]);
     }
-};
+}
 
 export default {
     SearchAndCreateMusic

--- a/src/modules/db/User.ts
+++ b/src/modules/db/User.ts
@@ -55,7 +55,7 @@ const myLikeMumentList = async (userId: string) => {
             JOIN music ON mument.music_id = music.id
             LEFT JOIN mument_tag ON mument.id = mument_tag.mument_id
             JOIN user ON mument.user_id = user.id
-            WHERE mument.like.user_id=${userId} AND mument.is_deleted=0
+            WHERE mument.like.user_id=${userId} AND mument.is_deleted=0 AND mument.is_private=0
             ORDER BY mument.created_at DESC;`;
     
     const myMumentList: MyMumentInfoRDB[] = await pools.query(mumentListQuery);

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -22,7 +22,7 @@ const message = {
     DELETE_BLOCKED_USER_SUCCESS: '유저 차단 해제 성공',
     READ_NEWS_LIST_SUCCESS: '소식창 리스트 조회 성공',
     DELETE_NEWS_SUCCESS: '소식창 알림 제거 성공',
-
+    READ_UNREAD_NEWS_SUCCESS: '소식창 새로운 알림 읽음 처리 성공',
 
     // mument
     NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -20,6 +20,8 @@ const message = {
     SELF_BLOCK: '자기자신은 차단할 수 없습니다',
     READ_BLOCK_LIST: '차단 유저 조회 성공',
     DELETE_BLOCKED_USER_SUCCESS: '유저 차단 해제 성공',
+    READ_NEWS_LIST_SUCCESS: '소식창 리스트 조회 성공',
+
 
     // mument
     NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -23,6 +23,7 @@ const message = {
     READ_NEWS_LIST_SUCCESS: '소식창 리스트 조회 성공',
     DELETE_NEWS_SUCCESS: '소식창 알림 제거 성공',
     READ_UNREAD_NEWS_SUCCESS: '소식창 새로운 알림 읽음 처리 성공',
+    READ_UNREAD_NEWS_IS_EXIST_SUCCESS: '새로 추가된 알림이 있는지 조회 성공',
 
     // mument
     NO_MUMENT_ID: '해당 아이디의 뮤멘트가 존재하지 않습니다',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -21,6 +21,7 @@ const message = {
     READ_BLOCK_LIST: '차단 유저 조회 성공',
     DELETE_BLOCKED_USER_SUCCESS: '유저 차단 해제 성공',
     READ_NEWS_LIST_SUCCESS: '소식창 리스트 조회 성공',
+    DELETE_NEWS_SUCCESS: '소식창 알림 제거 성공',
 
 
     // mument

--- a/src/routes/MumentRouter.ts
+++ b/src/routes/MumentRouter.ts
@@ -7,7 +7,7 @@ import reportRestriction from '../middlewares/reportRestriction';
 const router: Router = Router();
 
 // 뮤멘트 기록하기
-router.post('/:musicId', auth, reportRestriction, MumentController.createMument);
+router.post('/:musicId', auth, MumentController.createMument);
 
 // 처음/다시 조회
 router.get('/:musicId/is-first', auth, MumentController.getIsFirst);
@@ -15,7 +15,7 @@ router.get('/:musicId/is-first', auth, MumentController.getIsFirst);
 // 뮤멘트 수정하기
 router.put('/:mumentId', [
     body('isFirst').notEmpty(),
-], auth, reportRestriction, MumentController.updateMument);
+], auth, MumentController.updateMument);
 
 
 // 히스토리 조회

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -10,5 +10,6 @@ router.get('/like/list', auth, UserController.getLikeMumentList);
 router.post('/block/:mumentId', auth, UserController.blockUser);
 router.delete('/block/:blockedUserId', auth, UserController.deleteBlockUser);
 router.get('/block', auth, auth, UserController.getBlockedUserList);
+router.get('/news', auth, UserController.getNewsList);
 
 export default router;

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -12,6 +12,7 @@ router.post('/block/:mumentId', auth, UserController.blockUser);
 router.delete('/block/:blockedUserId', auth, UserController.deleteBlockUser);
 router.get('/block', auth, auth, UserController.getBlockedUserList);
 
+router.get('/news/exist', auth, UserController.getUnreadNewsisExist);
 router.patch('/news/read', auth, UserController.updateUnreadNews);
 router.patch('/news/:newsId', auth, UserController.deleteNews);
 router.get('/news', auth, UserController.getNewsList);

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -12,6 +12,7 @@ router.post('/block/:mumentId', auth, UserController.blockUser);
 router.delete('/block/:blockedUserId', auth, UserController.deleteBlockUser);
 router.get('/block', auth, auth, UserController.getBlockedUserList);
 
+router.patch('/news/read', auth, UserController.updateUnreadNews);
 router.patch('/news/:newsId', auth, UserController.deleteNews);
 router.get('/news', auth, UserController.getNewsList);
 

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { body } from 'express-validator';
+import { body, param } from 'express-validator';
 import { UserController } from '../controllers';
 import auth from '../middlewares/auth';
 
@@ -7,9 +7,12 @@ const router: Router = Router();
 
 router.get('/my/list', auth, UserController.getMyMumentList);
 router.get('/like/list', auth, UserController.getLikeMumentList);
+
 router.post('/block/:mumentId', auth, UserController.blockUser);
 router.delete('/block/:blockedUserId', auth, UserController.deleteBlockUser);
 router.get('/block', auth, auth, UserController.getBlockedUserList);
+
+router.patch('/news/:newsId', auth, UserController.deleteNews);
 router.get('/news', auth, UserController.getNewsList);
 
 export default router;

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -48,7 +48,6 @@ import { NoticeInfoRDB } from '../interfaces/mument/NoticeInfoRDB';
 const createMument = async (userId: string, musicId: string, mumentCreateDto: MumentCreateDto): Promise<PostBaseResponseDto | null> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {    
         await connection.beginTransaction(); // 트랜잭션 적용 시작
@@ -91,7 +90,6 @@ const createMument = async (userId: string, musicId: string, mumentCreateDto: Mu
 const updateMument = async (mumentId: string, mumentUpdateDto: MumentCreateDto): Promise<StringBaseResponseDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         await connection.beginTransaction(); // 트랜잭션 적용 시작
@@ -139,7 +137,6 @@ const updateMument = async (mumentId: string, mumentUpdateDto: MumentCreateDto):
 const getMument = async (mumentId: string, userId: string): Promise<MumentResponseDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
     
     try {
         // 존재하지 않는 id의 뮤멘트를 조회하려고 할 때
@@ -213,7 +210,6 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
 const deleteMument = async (mumentId: string): Promise<void | null> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         await connection.beginTransaction(); // 트랜잭션 적용 시작
@@ -459,7 +455,6 @@ const getMumentHistory = async (userId: string, musicId: string, writerId: strin
 const createLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         await connection.beginTransaction();
@@ -523,7 +518,6 @@ const createLike = async (mumentId: string, userId: string): Promise<LikeCountRe
 const deleteLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
     
     try {
         await connection.beginTransaction();
@@ -811,9 +805,10 @@ const getNoticeList = async (): Promise<NoticeInfoRDB[]> => {
 const createReport = async (mumentId: string, reportCategory: number[], etcContent: string, userId: string): Promise<void | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
     
     try {
+        await connection.beginTransaction(); //롤백을 위해 필요함
+
         // 신고 당하는 유저 id 가져오기
         const reportedMument = await mumentDB.isExistMumentInfo(mumentId, connection);
         let reportedUser: number;

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -48,6 +48,7 @@ import { NoticeInfoRDB } from '../interfaces/mument/NoticeInfoRDB';
 const createMument = async (userId: string, musicId: string, mumentCreateDto: MumentCreateDto): Promise<PostBaseResponseDto | null> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {    
         await connection.beginTransaction(); // 트랜잭션 적용 시작
@@ -90,6 +91,7 @@ const createMument = async (userId: string, musicId: string, mumentCreateDto: Mu
 const updateMument = async (mumentId: string, mumentUpdateDto: MumentCreateDto): Promise<StringBaseResponseDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         await connection.beginTransaction(); // 트랜잭션 적용 시작
@@ -137,6 +139,7 @@ const updateMument = async (mumentId: string, mumentUpdateDto: MumentCreateDto):
 const getMument = async (mumentId: string, userId: string): Promise<MumentResponseDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
     
     try {
         // 존재하지 않는 id의 뮤멘트를 조회하려고 할 때
@@ -191,13 +194,13 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
             count: historyCount,
         };
 
-        await connection.commit(); // query1, query2 모두 성공시 커밋(데이터 적용)
+        await connection.commit(); // 모두 성공시 커밋(데이터 적용)
 
         
         return data;
     } catch (error) {
         console.log(error);
-        await connection.rollback(); // query1, query2 중 하나라도 에러시 롤백 (데이터 적용 원상복귀)
+        await connection.rollback(); // 하나라도 에러시 롤백 (데이터 적용 원상복귀)
         throw error;
     } finally {
         connection.release(); // pool connection 회수
@@ -210,6 +213,7 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
 const deleteMument = async (mumentId: string): Promise<void | null> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         await connection.beginTransaction(); // 트랜잭션 적용 시작
@@ -226,10 +230,10 @@ const deleteMument = async (mumentId: string): Promise<void | null> => {
         const query3 = 'DELETE FROM mument.like where mument_id = ?;';
         await connection.query(query3, [mumentId]);
 
-        await connection.commit(); // query1, query2 모두 성공시 커밋(데이터 적용)
+        await connection.commit(); // 모두 성공시 커밋(데이터 적용)
     } catch (error) {
         console.log(error);
-        await connection.rollback(); // query1, query2 중 하나라도 에러시 롤백 (데이터 적용 원상복귀)
+        await connection.rollback(); // 하나라도 에러시 롤백 (데이터 적용 원상복귀)
         throw error;
     } finally {
         connection.release(); // pool connection 회수
@@ -455,6 +459,7 @@ const getMumentHistory = async (userId: string, musicId: string, writerId: strin
 const createLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         await connection.beginTransaction();
@@ -518,6 +523,7 @@ const createLike = async (mumentId: string, userId: string): Promise<LikeCountRe
 const deleteLike = async (mumentId: string, userId: string): Promise<LikeCountResponeDto | null | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
     
     try {
         await connection.beginTransaction();
@@ -577,6 +583,8 @@ const deleteLike = async (mumentId: string, userId: string): Promise<LikeCountRe
         console.log(error);
         await connection.rollback();
         throw error;
+    } finally {
+        connection.release();
     }
 };
 
@@ -803,6 +811,7 @@ const getNoticeList = async (): Promise<NoticeInfoRDB[]> => {
 const createReport = async (mumentId: string, reportCategory: number[], etcContent: string, userId: string): Promise<void | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
     
     try {
         // 신고 당하는 유저 id 가져오기
@@ -834,10 +843,10 @@ const createReport = async (mumentId: string, reportCategory: number[], etcConte
         }, Promise.resolve());
 
 
-        await connection.commit(); // query1, query2 모두 성공시 커밋(데이터 적용)
+        await connection.commit(); // 모두 성공시 커밋(데이터 적용)
     } catch (error) {
         console.log(error);
-        await connection.rollback(); // query1, query2 중 하나라도 에러시 롤백 (데이터 적용 원상복귀)
+        await connection.rollback(); // 하나라도 에러시 롤백 (데이터 적용 원상복귀)
         throw error;
     } finally {
         connection.release(); // pool connection 회수

--- a/src/services/MumentService.ts
+++ b/src/services/MumentService.ts
@@ -139,7 +139,7 @@ const getMument = async (mumentId: string, userId: string): Promise<MumentRespon
     const connection = await pool.getConnection();
     
     try {
-        // 존재하지 않는 id의 뮤멘트를 수정하려고 할 때
+        // 존재하지 않는 id의 뮤멘트를 조회하려고 할 때
         const isExistMumentInfo: ExistMumentDto = await mumentDB.isExistMumentInfo(mumentId, connection);
         
         if (isExistMumentInfo.isExist === false) return constant.NO_MUMENT;
@@ -773,7 +773,6 @@ const getNoticeDetail = async (noticeId: string): Promise<NoticeInfoRDB | number
 
 // 공지사항 리스트 조회
 const getNoticeList = async (): Promise<NoticeInfoRDB[]> => {
-    const todayDate = dayjs().format('YYYY-MM-DD');
     try {
         const selectNoticeQuery = 'SELECT * FROM notice ORDER BY created_at DESC;'
         let noticeList: NoticeInfoRDB[] = await pools.query(selectNoticeQuery);

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -207,6 +207,7 @@ const getLikeMumentList = async (userId: string, tagList: number[]): Promise<Use
 const blockUser = async (userId: number, mumentId: string): Promise<number | NumberBaseResponseDto> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         // 뮤멘트 작성자 id 가져오기
@@ -343,6 +344,7 @@ const updateUnreadNews  = async (userId: number, unreadNews: number[]): Promise<
 const deleteNews = async (userId: number, newsId: number): Promise<void | number> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
+    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
         const updateNewsQuery = `

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -108,7 +108,6 @@ const getMyMumentList = async (userId: string, tagList: number[]): Promise<UserM
  */
 const getLikeMumentList = async (userId: string, tagList: number[]): Promise<UserMumentListResponseDto | null> => {
     try {
-       
         // 좋아요한 뮤멘트 리스트 가져오기
         let likeMumentList: MyMumentInfoRDB[] = await userDB.myLikeMumentList(userId);
 
@@ -207,9 +206,10 @@ const getLikeMumentList = async (userId: string, tagList: number[]): Promise<Use
 const blockUser = async (userId: number, mumentId: string): Promise<number | NumberBaseResponseDto> => {
     const pool: any = await poolPromise;
     const connection = await pool.getConnection();
-    connection.beginTransaction(); //롤백을 위해 필요함
 
     try {
+        await connection.beginTransaction(); //롤백을 위해 필요함
+
         // 뮤멘트 작성자 id 가져오기
         const blockedMument = await mumentDB.isExistMumentInfo(mumentId, connection);
         let blockedUser: number;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -323,7 +323,6 @@ const getUnreadNewsisExist = async (userId: number): Promise<NumberBaseResponseD
         const data = await connection.query(selectNewsQeury, [
             userId,  comparedDate, dayjs(curr).format()
         ]);
-        console.log(data);
 
         if (data.length > 0) return { exist: 1 };
         else return { exist: 0 };

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -317,20 +317,26 @@ const getNewsList = async (userId: number) => {
             SELECT * FROM news WHERE user_id=? AND is_deleted=0 ORDER BY created_at DESC;
         `;
         const newsList: NewsInfoRDB[]  = await connection.query(selectNewsQuery, [userId]);
+
+        const curr = new Date();
+        const comparedDate = dayjs(curr).subtract(2, 'week').format();
         
         const newsListDateFormat = async (item: NewsInfoRDB, idx: number) => {
-            result.push({
-                id: item.id,
-                type: item.type,
-                userId: item.user_id,
-                isDeleted: item.is_deleted,
-                isRead: item.is_read,
-                createdAt: dayjs(item.created_at).format('MM/DD HH:mm'),
-                linkId: item.link_id,
-                noticeTitle: item.notice_title,
-                likeProfileId: item.like_profile_id,
-                likeMusicTitle: item.like_music_title
-            });
+            // 최근 2주전 알림만 보여줌
+            if (dayjs(comparedDate).isBefore(item.created_at)) {
+                result.push({
+                    id: item.id,
+                    type: item.type,
+                    userId: item.user_id,
+                    isDeleted: item.is_deleted,
+                    isRead: item.is_read,
+                    createdAt: dayjs(item.created_at).format('MM/DD HH:mm'),
+                    linkId: item.link_id,
+                    noticeTitle: item.notice_title,
+                    likeProfileId: item.like_profile_id,
+                    likeMusicTitle: item.like_music_title
+                });
+            }
         };
 
         await newsList.reduce(async (acc, curr, index) => {

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -258,6 +258,9 @@ const blockUser = async (userId: number, mumentId: string): Promise<number | Num
     }
 };
 
+/**
+ *  유저 차단 취소
+ */
 const deleteBlockUser = async (userId: number, blockedUserId: string): Promise<void> => {
     try {
         const deleteBlockQuery = `DELETE FROM block WHERE user_id=? AND blocked_user_id=?`;
@@ -273,6 +276,10 @@ const deleteBlockUser = async (userId: number, blockedUserId: string): Promise<v
     }
 };
 
+
+/**
+ *  차단 유저 리스트 조회
+ */
 const getBlockedUserList = async (userId: number): Promise<UserResponseDto[] | number> => {
     try {
         const selectBlockQuery = `

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -305,6 +305,38 @@ const getBlockedUserList = async (userId: number): Promise<UserResponseDto[] | n
 
 
 /**
+ * 소식창에 안읽은 알림이 있는지 조회
+ */
+const getUnreadNewsisExist = async (userId: number): Promise<NumberBaseResponseDto> => {
+    const pool: any = await poolPromise;
+    const connection = await pool.getConnection();
+
+    try {
+        const curr = new Date();
+        const comparedDate = dayjs(curr).subtract(2, 'week').format();
+        
+        const selectNewsQeury = `
+            SELECT * FROM news 
+            WHERE user_id=? AND is_deleted=0 AND is_read=0 AND created_at BETWEEN ? AND ?
+        `;
+
+        const data = await connection.query(selectNewsQeury, [
+            userId,  comparedDate, dayjs(curr).format()
+        ]);
+        console.log(data);
+
+        if (data.length > 0) return { exist: 1 };
+        else return { exist: 0 };
+
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+
+};
+
+
+/**
  * 소식창 새로운 알림 읽음 처리
  */
 const updateUnreadNews  = async (userId: number, unreadNews: number[]): Promise<void | number> => {
@@ -425,6 +457,7 @@ export default {
     blockUser,
     deleteBlockUser,
     getBlockedUserList,
+    getUnreadNewsisExist,
     updateUnreadNews,
     deleteNews,
     getNewsList,


### PR DESCRIPTION
## **💿 DESCRIPTION**
소식창 시리즈 구현 완료
- [x] GET 소식창 리스트 조회 API
- [x] PATCH 소식창 알림 제거 API
- [x] GET 새로운 알림 유무 조회 API
- [x] PATCH 새로운 알림 읽음 처리 API

## **🎙 RELATED ISSUE**
#106 

## **💃 REVIEW POINT**
- [x] GET 소식창 리스트 조회 API
- 삭제되지 않은 최근 2주 내의 알림만 최신순 정렬
- 공지사항 알림, 좋아요 뷰에 필요한 모든 필드 null아니면 해당되는 값 넣음

- [x] PATCH 소식창 알림 제거 API
- 본인의 알림 id가 아님 or 이미 삭제된 알림 or 존재하지않는 알림 id 알 때 400
update 쿼리 결과에서 changedRows라는 필드값에 변화시킨 로우의 개수가 나오기때문에 이점을 이용해서 대비함

-> **공지사항 생성 API 생성 시 -> 모든 유저 별로 소식창 DB에 삽입해줘야지 나중에 소식창 알림 제거하는 걸 관리할 수 있음

- [x] GET 새로운 알림 유무 조회 API
- 삭제되지않은 알람 중 안읽은 알림 존재 유무 판단함
- 소식창 리스트와 똑같이 최근 2주 이내 

- [x] PATCH 새로운 알림 읽음 처리 API