### PR TITLE
[MOD] 카카오 로그인, 프로필 설정 관련 수정

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -13,17 +13,10 @@ import { AuthTokenResponseDto } from '../interfaces/auth/AuthTokenResponseDto';
  * @DESC match user profileId and password
  */
 const login = async (req: Request, res: Response) => {
-    const { provider, authentication_code, kakao_refresh, fcm_token } = req.body;
+    const { provider, authentication_code, fcm_token } = req.body;
 
     try {
-        let data: number | AuthTokenResponseDto = 0;
-
-        if (kakao_refresh) {
-            data = await AuthService.login(provider, authentication_code, kakao_refresh, fcm_token);
-        } else {
-            data = await AuthService.login(provider, authentication_code, null, fcm_token);
-        }
-
+        const data = await AuthService.login(provider, authentication_code, fcm_token);
 
         switch (data) {
             case constant.NO_AUTHENTICATION_CODE: {
@@ -37,10 +30,6 @@ const login = async (req: Request, res: Response) => {
             case constant.NO_IDENTITY_TOKEN_SUB: {
                 // 애플 - authorization code에 sub값이 없을 때
                 return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_IDENTITY_TOKEN_SUB));
-            }
-            case constant.NO_KAKAO_REFRESH_TOKEN: {
-                // 카카오 - 리프래쉬 토큰값이 없을 때
-                return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_KAKAO_REFRESH_TOKEN));
             }
             case constant.NO_USER: {
                 // 카카오 - 회원가입 진행 중 유저가 생성되지 않았을 때

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -13,23 +13,19 @@ import { AuthTokenResponseDto } from '../interfaces/auth/AuthTokenResponseDto';
  * @DESC match user profileId and password
  */
 const login = async (req: Request, res: Response) => {
-    const { provider, authentication_code, kakaoRefresh, fcm_token } = req.body;
+    const { provider, authentication_code, kakao_refresh, fcm_token } = req.body;
 
     try {
         let data: number | AuthTokenResponseDto = 0;
 
-        if (kakaoRefresh) {
-            data = await AuthService.login(provider, authentication_code, kakaoRefresh, fcm_token);
+        if (kakao_refresh) {
+            data = await AuthService.login(provider, authentication_code, kakao_refresh, fcm_token);
         } else {
             data = await AuthService.login(provider, authentication_code, null, fcm_token);
         }
 
 
         switch (data) {
-            case 0: {
-
-            }
-
             case constant.NO_AUTHENTICATION_CODE: {
                 // 공통 - authentication code가 없는 경우
                 return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_AUTHENTICATION_CODE));
@@ -41,6 +37,10 @@ const login = async (req: Request, res: Response) => {
             case constant.NO_IDENTITY_TOKEN_SUB: {
                 // 애플 - authorization code에 sub값이 없을 때
                 return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_IDENTITY_TOKEN_SUB));
+            }
+            case constant.NO_KAKAO_REFRESH_TOKEN: {
+                // 카카오 - 리프래쉬 토큰값이 없을 때
+                return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_KAKAO_REFRESH_TOKEN));
             }
             case constant.NO_USER: {
                 // 카카오 - 회원가입 진행 중 유저가 생성되지 않았을 때

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -13,12 +13,23 @@ import { AuthTokenResponseDto } from '../interfaces/auth/AuthTokenResponseDto';
  * @DESC match user profileId and password
  */
 const login = async (req: Request, res: Response) => {
-    const { provider, authentication_code, fcm_token } = req.body;
+    const { provider, authentication_code, kakaoRefresh, fcm_token } = req.body;
 
     try {
-        const data = await AuthService.login(provider, authentication_code, fcm_token);
+        let data: number | AuthTokenResponseDto = 0;
+
+        if (kakaoRefresh) {
+            data = await AuthService.login(provider, authentication_code, kakaoRefresh, fcm_token);
+        } else {
+            data = await AuthService.login(provider, authentication_code, null, fcm_token);
+        }
+
 
         switch (data) {
+            case 0: {
+
+            }
+
             case constant.NO_AUTHENTICATION_CODE: {
                 // 공통 - authentication code가 없는 경우
                 return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.NO_AUTHENTICATION_CODE));

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -517,9 +517,13 @@ const getNewsList = async (req: Request, res: Response) => {
  * @DESC 프로필 설정이 완료되었는지 확인하는 API입니다.
  */
 const checkProfileSet = async (req: Request, res: Response) => {
+    const userId = req.body.userId;
+
     try {
-        // auth에서 401이 리턴되지 않았다면 204 리턴
-        res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT, message.COMPLETE_PROFILE_SET));
+        const data = await UserService.checkProfileSet(userId);
+
+        if (data) return res.status(statusCode.NO_CONTENT).send(util.success(statusCode.NO_CONTENT, message.COMPLETE_PROFILE_SET));
+        else return res.status(statusCode.OK).send(util.success(statusCode.OK, message.PROFILE_SET_REQUIRED));        
     } catch (error) {
         console.log(error);
 

--- a/src/library/jwtHandler.ts
+++ b/src/library/jwtHandler.ts
@@ -45,9 +45,6 @@ const verify = (token: string) => {
     try {
         const decoded = jwt.verify(token, config.jwtSecret);
 
-        // 프로필 설정이 완료되지 않은 토큰일 때
-        if (decoded.profileId === null) return constant.NOT_PROFILE_SET_TOKEN;
-
         return decoded;
     } catch (err: any) {
         if (err.name == TokenExpiredError) {

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -40,9 +40,6 @@ export default async (req: Request, res: Response, next: NextFunction) => {
                 case constant.TOKEN_UNKNOWN_ERROR: {
                     return res.status(statusCode.UNAUTHORIZED).send(util.fail(statusCode.UNAUTHORIZED, message.TOKEN_UNKNOWN_ERROR));
                 }
-                case constant.NOT_PROFILE_SET_TOKEN: {
-                    return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, message.PROFILE_SET_REQUIRED));
-                }
             }
 
         } else {

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -73,6 +73,7 @@ const message = {
     APPLE_TOKEN_UNAUTHORIZED: '애플 API 개발자 토큰이 유효하지 않습니다',
     APPLE_SERVER_INTERNAL_ERROR: '애플 API 서버 자체 에러',
     NO_AUTHENTICATION_CODE: 'authentication code값이 없습니다',
+    NO_KAKAO_REFRESH_TOKEN: '카카오 리프래쉬 토큰값이 없습니다',
     NOT_CORRECT_TOKEN: 'refresh token이 일치하지 않습니다',
     RENEW_ACCESS_TOKEN: 'access token 갱신 성공',
     RENEW_ACCESS_REFRESH_TOKEN: 'access token과 refresh token 갱신 성공',

--- a/src/modules/serviceReturnConstant.ts
+++ b/src/modules/serviceReturnConstant.ts
@@ -25,7 +25,8 @@ const constant = {
 
     // kakao
     NO_AUTHENTICATION_CODE: -60, // authenticationCode가 클라이언트로부터 넘어오지 않았을 때
-    INVALID_AUTHENTICATION_CODE: -61, // authenticationCode로 토큰 발근 or 프로필 조회가 불가할 때
+    INVALID_AUTHENTICATION_CODE: -61, // authenticationCode로 토큰 발급 or 프로필 조회가 불가할 때
+    NO_KAKAO_REFRESH_TOKEN: -62, // 카카오 리프래쉬 토큰이 넘어오지 않았을 때
 
     // jwt token
     TOKEN_EXPIRED: -100, // 토큰이 만료되었을 때

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -768,7 +768,23 @@ const postNotice = async (title: string, content:string): Promise<NoticePushResp
         connection.release(); // pool connection 회수
     }
 };
+/**
+ * 프로필 설정이 완료되었는지 확인
+ */
+const checkProfileSet = async (userId: string): Promise<boolean> => {
+    try {
+        // userId로 유저 정보 가져오기
+        const user = await userDB.userInfo(userId);
 
+        // 프로필 설정이 완료되지 않았으면 false 리턴
+        if (!user.profile_id) return false;
+
+        return true;
+    } catch (error) {
+        console.log(error);
+        throw error;
+    }
+};
 
 export default {
     getMyMumentList,
@@ -786,4 +802,5 @@ export default {
     deleteNews,
     getNewsList,
     postNotice,
+    checkProfileSet,
 };


### PR DESCRIPTION
## **💿 DESCRIPTION**
- 카카오 로그인 시 authentication code에 액세스 토큰을 받도록 로직 수정 (db에는 유저의 고유 id값이 저장됨)
- 토큰을 확인했을 때 프로필 설정이 미완료되었으면 400 리턴하는 로직 삭제
- 프로필 설정 확인 API service단 추가

## **🎙 RELATED ISSUE**
#122 

## **💃 REVIEW POINT**
- kakao access token값과 refresh token값은 로그인할 때마다 바뀌므로, 카카오단에 토큰을 보내고 받은 고유 id값을 db에 저장하도록 수정하였습니다.
- 프로필 설정 API와 닉네임 중복 확인 API에서도 프로필 설정이 미완료되었을 시 400 리턴되는 문제가 있었습니다.
따라서 auth 미들웨어에서 400을 리턴하는 로직을 삭제하였습니다.
대신, 프로필 설정을 확인하는 API의 서비스 로직을 추가하였습니다.
